### PR TITLE
temporarily disable seren card on dashboard

### DIFF
--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -26,8 +26,8 @@ class MainController < ApplicationController
     @content = current_user.send(content_type).sample
 
     begin
-      questionable_params = @content.class.attribute_categories.flat_map { |_k, v| v[:attributes] }.reject { |k| k.end_with?('_id') }
-      @question = QuestionService.question(Content.new @content.slice(*questionable_params))
+      #questionable_params = @content.class.attribute_categories.flat_map { |_k, v| v[:attributes] }.reject { |k| k.end_with?('_id') }
+      #@question = QuestionService.question(Content.new @content.slice(*questionable_params))
     rescue
     end
   end


### PR DESCRIPTION
translations are missing when card appears on dashboard, hiding it until it's fixed