### PR TITLE
Add smarter placeholders to content forms

### DIFF
--- a/app/views/content/form/_text_input.html.erb
+++ b/app/views/content/form/_text_input.html.erb
@@ -1,5 +1,6 @@
 <%
   field_id = "#{f.object.class.name.downcase}_#{attribute}"
+  class_name = f.object.class.name.downcase
 
   # TODO: Enable autocomplete when we can actually hide the dropdown if someone tabs out of a field.
   #       Not the easiest thing in the world to do, apparently.
@@ -7,7 +8,15 @@
 
 <div class="input-field content-field">
   <%= f.label attribute, attribute.humanize.capitalize %>
-  <%= f.text_area attribute, class: "materialize-textarea #{defined?(autocomplete) && false ? 'autocomplete' : ''}", placeholder: 'Write as little or as much as you want!' %>
+  <%
+    placeholder = t("serendipitous_questions.attributes.#{class_name}.#{attribute}")
+    placeholder = I18n.translate "attributes.#{class_name}.#{attribute}",
+      scope: :serendipitous_questions,
+      name: f.object.send('name') || "this #{class_name}",
+      attribute: "test",
+      default: 'Write as little or as much as you want!'
+  %>
+  <%= f.text_area attribute, class: "materialize-textarea #{defined?(autocomplete) && false ? 'autocomplete' : ''}", placeholder: placeholder %>
 </div>
 
 <% if defined?(autocomplete) && false %>

--- a/app/views/content/form/_text_input.html.erb
+++ b/app/views/content/form/_text_input.html.erb
@@ -9,7 +9,6 @@
 <div class="input-field content-field">
   <%= f.label attribute, attribute.humanize.capitalize %>
   <%
-    placeholder = t("serendipitous_questions.attributes.#{class_name}.#{attribute}")
     placeholder = I18n.translate "attributes.#{class_name}.#{attribute}",
       scope: :serendipitous_questions,
       name: f.object.send('name') || "this #{class_name}",


### PR DESCRIPTION
Uses @Cantido's awesome serendipitous-question i18n stuff to make content form placeholders a bit better too.

![2016-10-11-114659_889x488_scrot](https://cloud.githubusercontent.com/assets/538235/19266148/800c3618-8fa8-11e6-9578-924916c8f1fd.png)
