### PR TITLE
Update Select Dropdown Styles

### DIFF
--- a/app/assets/stylesheets/forms.css
+++ b/app/assets/stylesheets/forms.css
@@ -1,3 +1,8 @@
 .help-text {
 	color: #999999;
 }
+
+.input-select .select-wrapper {
+	margin-top: 13px;
+	margin-bottom: 20px;
+}

--- a/app/views/content/_form.html.erb
+++ b/app/views/content/_form.html.erb
@@ -68,19 +68,19 @@
                   <%= render 'content/form/relation_input', f: f, attribute: attribute, relation: through_class %>
 
                 <% elsif attribute == 'archetype' %>
-                  <div class="input-field">
-                    <%= f.label attribute %><br />
+                  <div class="input-field input-select">
+                    <%= f.label attribute, class: 'active' %><br />
                     <%= f.select attribute, options_for_select(t('archetypes'), selected: f.object.archetype), include_blank: true %>
                   </div>
 
                 <% elsif attribute == 'universe_id' %>
-                  <div class="input-field">
-                    <%= f.label attribute %><br />
+                  <div class="input-field input-select">
+                    <%= f.label attribute, class: 'active' %><br />
                     <%= f.select attribute, current_user.universes.sort_by(&:name).map { |u| [u.name, u.id] }.compact, include_blank: true, selected: (f.object.persisted? ? f.object.universe_id : session[:universe_id]) %>
                   </div>
 
                 <% elsif attribute == 'privacy' %>
-                  <div class="input-field">
+                  <div class="input-field input-select">
                     <%= f.label attribute %><br />
                     <%= f.select attribute, [['Only visible to you', 'private'], ['Visible to anyone with the URL', 'public']] %>
                     <div class="help-text">


### PR DESCRIPTION
## Description
Update the select dropdown styles to match the rest of the text area inputs.

Fixes https://github.com/indentlabs/notebook/issues/123

#### Character Creation
Archetype & Universe are updated.
<img width="1424" alt="screen shot 2016-10-12 at 10 12 01 am" src="https://cloud.githubusercontent.com/assets/3017491/19315792/b56a3154-9064-11e6-9754-8dec3990dbaf.png">

#### Universe Creation
A slight bit of padding is added between the privacy label and the dropdown.
<img width="1422" alt="screen shot 2016-10-12 at 10 12 49 am" src="https://cloud.githubusercontent.com/assets/3017491/19315805/cad258b4-9064-11e6-9743-7297aa24a9d1.png">