### PR TITLE
Fix Stretched Image on About Page

### DIFF
--- a/app/assets/stylesheets/landing.scss
+++ b/app/assets/stylesheets/landing.scss
@@ -3,3 +3,48 @@
 		font-size: 120%;
 	}
 }
+
+.hero {
+	position: relative;
+	overflow: hidden;
+	height: 35rem;
+
+	&--small {
+		height: 24rem;
+
+		.hero-image {
+			-webkit-transform: translate3d(-50%, 400px, 0px) scale(0.7);
+		  transform: translate3d(-50%, 400px, 0px) scale(0.7);
+		}
+	}
+
+	.hero-content {
+		padding: 2rem;
+		position: absolute;
+
+		&.lower-left {
+			bottom: 0;
+		}
+	}
+
+	.hero-container {
+		position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: -1;
+	}
+
+	.hero-image {
+		display: block;
+		opacity: 0.25;
+    position: absolute;
+    left: 50%;
+    bottom: 0;
+    min-width: 100%;
+    min-height: 100%;
+    -webkit-transform: translate3d(-50%, 300px, 0px);
+		transform: translate3d(-50%, 300px, 0px);
+	}
+}

--- a/app/assets/stylesheets/landing.scss
+++ b/app/assets/stylesheets/landing.scss
@@ -1,50 +1,50 @@
 .perks-section {
-	i[class=material-icons] {
-		font-size: 120%;
-	}
+  i[class=material-icons] {
+    font-size: 120%;
+  }
 }
 
 .hero {
-	position: relative;
-	overflow: hidden;
-	height: 35rem;
+  position: relative;
+  overflow: hidden;
+  height: 35rem;
 
-	&--small {
-		height: 24rem;
+  &--small {
+    height: 24rem;
 
-		.hero-image {
-			-webkit-transform: translate3d(-50%, 400px, 0px) scale(0.7);
-		  transform: translate3d(-50%, 400px, 0px) scale(0.7);
-		}
-	}
+    .hero-image {
+      -webkit-transform: translate3d(-50%, 400px, 0px) scale(0.7);
+      transform: translate3d(-50%, 400px, 0px) scale(0.7);
+    }
+  }
 
-	.hero-content {
-		padding: 2rem;
-		position: absolute;
+  .hero-content {
+    padding: 2rem;
+    position: absolute;
 
-		&.lower-left {
-			bottom: 0;
-		}
-	}
+    &.lower-left {
+      bottom: 0;
+    }
+  }
 
-	.hero-container {
-		position: absolute;
+  .hero-container {
+    position: absolute;
     top: 0;
     left: 0;
     right: 0;
     bottom: 0;
     z-index: -1;
-	}
+  }
 
-	.hero-image {
-		display: block;
-		opacity: 0.25;
+  .hero-image {
+    display: block;
+    opacity: 0.25;
     position: absolute;
     left: 50%;
     bottom: 0;
     min-width: 100%;
     min-height: 100%;
     -webkit-transform: translate3d(-50%, 300px, 0px);
-		transform: translate3d(-50%, 300px, 0px);
-	}
+    transform: translate3d(-50%, 300px, 0px);
+  }
 }

--- a/app/views/main/about_notebook.html.erb
+++ b/app/views/main/about_notebook.html.erb
@@ -1,22 +1,25 @@
-  <div>
-    <div class="card">
-      <div class="card-image">
-        <%= image_tag 'landing/digital-notebook.jpg', style: "height: 600px;" %>
-        <span class="card-title">Your digital notebook is here.</span>
-      </div>
-      <div class="card-content">
-        <h4>
-          Notebook is a set of tools for writers, game designers, and roleplayers to create magnificent universes &ndash; and everything within them.
-        </h4>
-        <p>
-          From a simple interface in your browser, on your phone, or on your tablet, you can do everything you'd ever want to do while creating your own little (or big!) world.
-        </p>
-      </div>
-      <div class="card-action">
-        <%= link_to 'Get started', new_user_registration_path %>
-      </div>
-    </div>
+<div class="hero hero--small">
+  <div class="hero-content lower-left">
+    <h3 class="teal-text text-lighten-2">Your digital notebook is here.</h1>
   </div>
+  <div class="hero-container">
+    <%= image_tag 'landing/digital-notebook.jpg', class: 'hero-image' %>
+  </div>
+</div>
+
+<div class="card">
+  <div class="card-content">
+    <h4>
+      Notebook is a set of tools for writers, game designers, and roleplayers to create magnificent universes &ndash; and everything within them.
+    </h4>
+    <p>
+      From a simple interface in your browser, on your phone, or on your tablet, you can do everything you'd ever want to do while creating your own little (or big!) world.
+    </p>
+  </div>
+  <div class="card-action">
+    <%= link_to 'Get started', new_user_registration_path %>
+  </div>
+</div>
 
 <div class="row">
   <div class="col s3">

--- a/app/views/main/index.html.erb
+++ b/app/views/main/index.html.erb
@@ -1,4 +1,4 @@
-<div id="index-banner" class="parallax-container">
+<div id="index-banner" class="hero">
     <div class="section no-pad-bot">
       <div class="container">
         <br><br>
@@ -20,8 +20,8 @@
 
       </div>
     </div>
-    <div class="parallax">
-      <%= image_tag 'landing/digital-notebook.jpg', style: 'display: block; transform: translate3d(-50%, 342px, 0px); opacity: 0.25' %>
+    <div class="hero-container">
+      <%= image_tag 'landing/digital-notebook.jpg', class: 'hero-image' %>
     </div>
   </div>
 
@@ -176,7 +176,7 @@
     </div>
   </div>
 
-  <div class="parallax-container valign-wrapper">
+  <div class="hero valign-wrapper">
     <div class="container center">
       <h5 class="header light">
         <strong>"Imagine sliced bread as a notebook. This is even better."</strong>
@@ -184,8 +184,8 @@
         &mdash; Andrew Brown, Author & CEO
       </h5>
     </div>
-    <div class="parallax">
-      <%= image_tag 'landing/screenshot.png', style: 'display: block; transform: translate3d(-50%, 145px, 0px); opacity: 0.25' %>
+    <div class="hero-container">
+      <%= image_tag 'landing/screenshot.png', class: 'hero-image'%>
     </div>
   </div>
 


### PR DESCRIPTION
## Description
The image on the about page now scales appropriately and matches the style on the index page. Instead of using unique inline styles, there is now a `hero` class that consolidates the styles across both pages.

Fixes https://github.com/indentlabs/notebook/issues/134

### New About Page
<img width="1440" alt="screen shot 2016-10-15 at 3 19 20 pm" src="https://cloud.githubusercontent.com/assets/3017491/19413190/1f17b250-92ec-11e6-9376-173d3edcdbd8.png">