### PR TITLE
fixed notebook.ai url in readme

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -5,7 +5,7 @@
 {<img src="http://inch-ci.org/github/indentlabs/notebook.svg?branch=master" alt="Inline docs" />}[http://inch-ci.org/github/indentlabs/notebook]
 
 == What is notebook?
-see {live website}[http://indentapp.com]
+see {live website}[http://notebook.ai/]
 
 notebook is a set of tools for writers, game designers, and roleplayers to create magnificent universes – and everything within them.
 


### PR DESCRIPTION
The original README goes to http://indentapp.com/ which I don't think is correct, so here's a fix for that.