### PR TITLE
Make content links open in a new tab

### DIFF
--- a/app/views/content/show.html.erb
+++ b/app/views/content/show.html.erb
@@ -33,7 +33,8 @@
             Redcarpet::Render::HTML.new(
               with_toc_data: true,
               safe_links_only: true,
-              filter_html: true
+              filter_html: true,
+              link_attributes: {target: '_blank'}
             ),
             autolink: true,
             tables: true,


### PR DESCRIPTION
Adds a _blank target to content links so they open in a new tab rather than making the browser leave the content.