### PR TITLE
Fix Universe names upon export

### DIFF
--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -142,7 +142,7 @@ class ExportController < ApplicationController
           if value.is_a?(ActiveRecord::Associations::CollectionProxy)
             value = value.map(&:name).to_sentence
           elsif attr.name.end_with?('_id') && value.present?
-            universe = Universe.where(id: value.to_i)
+            universe = Universe.where(id: value.to_i).first
             value = universe.name if universe
           end
 


### PR DESCRIPTION
Fixes #176 

```
irb(main):001:0> Universe.where(id: 1.to_i).class.name
=> "ActiveRecord::Relation"

irb(main):002:0> Universe.where(id: 1.to_i).first.class.name
=> "Universe"
```