### PR TITLE
Re-show checkboxes that were hidden by materialize

### DIFF
--- a/app/assets/stylesheets/fixes.scss
+++ b/app/assets/stylesheets/fixes.scss
@@ -1,0 +1,11 @@
+/*
+ * These are temporary fixes and/or hacks for issues seen in prod. Every line here
+ * should be assumed temporary and with an inherit desire to remove it with something
+ * cleaner.
+ */
+
+// For some reason, the latest materializecss hides checkboxes. This un-hides them.
+input[type="checkbox"]:not(:checked), input[type="checkbox"]:checked {
+  position: inherit !important;
+  opacity: inherit !important;
+}


### PR DESCRIPTION
This fixes the "Remember me" box on sign in, as well as the checkboxes in user preferences.