### PR TITLE
Fix heights for landing page cards

### DIFF
--- a/app/assets/stylesheets/materialize-overrides.scss
+++ b/app/assets/stylesheets/materialize-overrides.scss
@@ -2,3 +2,17 @@
 .row .col {
   padding: 0 0.25rem !important;
 }
+
+@media only screen and (min-width: 1024px) {
+  .fixed-card-content
+  {
+    height: 8em; 
+  }
+}
+
+@media only screen and (max-width: 1024px) {
+  .fixed-card-content
+  {
+    height: 10em; 
+  }
+}

--- a/app/views/cards/intros/_content_type_intro.html.erb
+++ b/app/views/cards/intros/_content_type_intro.html.erb
@@ -8,7 +8,7 @@
     <%= image_tag "card-headers/#{content_name.pluralize}.jpg", height: 300, width: 300 %>
     <span class="card-title">Create <%= content_name == "magic" ? 'magic' : content_name.pluralize %></span>
   </div>
-  <div class="card-content">
+  <div class="card-content fixed-card-content">
     <p>
       <%= t("content_descriptions.#{content_name}") %>
     </p>


### PR DESCRIPTION
Create a new class to give a card fixed height instead of allowing the size of the text to determine its height.
The exact value of the fixed height is determined by the screen size.

Fixes #

Changes proposed:

 - 
 
 -
 
 -

@indentlabs/contributors
