### PR TITLE
Jan 15 bugfix release

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1,0 +1,3 @@
+.container-fluid {
+  margin: 0 30px;
+}

--- a/app/assets/stylesheets/thredded-overrides.scss
+++ b/app/assets/stylesheets/thredded-overrides.scss
@@ -85,6 +85,14 @@
   }
 }
 
+.thredded--form {
+  input[type="checkbox"] {
+    position: relative !important;
+    opacity: 1 !important;
+    pointer-events: inherit !important;
+  }
+}
+
 .thredded--messageboard--byline {
   i.material-icons {
     font-size: 0.9em;

--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -44,23 +44,8 @@ class MainController < ApplicationController
     # todo optimize this / use Attributes
     return [] if @activated_content_types.nil?
 
-    @recent_edits = @activated_content_types.flat_map { |klass|
-      klass.constantize
-           .where(user_id: current_user.id)
-           .order(updated_at: :desc)
-           .limit(100)
-    }.sort_by(&:updated_at)
-    .last(100)
-    .reverse
-
-    @recent_creates = @activated_content_types.flat_map { |klass|
-      klass.constantize
-           .where(user_id: current_user.id)
-           .order(created_at: :desc)
-           .limit(100)
-    }.sort_by(&:created_at)
-    .last(100)
-    .reverse
+    @recent_edits = current_user.recent_content_list(limit: 50)
+    @recent_creates = current_user.recent_content_list_by_create(limit: 50)
   end
 
   def for_writers

--- a/app/models/concerns/has_content.rb
+++ b/app/models/concerns/has_content.rb
@@ -101,7 +101,7 @@ module HasContent
     end
 
     # [..., ..., ...]
-    def recent_content_list
+    def recent_content_list(limit: 10)
       # Todo: I think this is more optimized, but the group introduces weird
       # ordering of the results, so we're building it a bit less optimized below
       # just to ensure it's actually correct.
@@ -112,10 +112,31 @@ module HasContent
 
       recently_changed_attributes = Attribute.where(user: self)
                                              .order('updated_at desc')
-                                             .limit(100)
+                                             .limit(limit * 100)
                                              .group_by { |r| [r.entity_type, r.entity_id] }
                                              .keys
-                                             .first(10)
+                                             .first(limit)
+
+      @user_recent_content_list = recently_changed_attributes.map do |entity_type, entity_id|
+        entity_type.constantize.find_by(id: entity_id)
+      end.compact
+    end
+
+    def recent_content_list_by_create(limit: 10)
+      # Todo: I think this is more optimized, but the group introduces weird
+      # ordering of the results, so we're building it a bit less optimized below
+      # just to ensure it's actually correct.
+      # recently_changed_attributes = Attribute.where(user: self)
+      #                                        .order('updated_at desc')
+      #                                        .group([:entity_type, :entity_id])
+      #                                        .limit(10)
+
+      recently_changed_attributes = Attribute.where(user: self)
+                                             .order('created_at desc')
+                                             .limit(limit * 100)
+                                             .group_by { |r| [r.entity_type, r.entity_id] }
+                                             .keys
+                                             .first(limit)
 
       @user_recent_content_list = recently_changed_attributes.map do |entity_type, entity_id|
         entity_type.constantize.find_by(id: entity_id)

--- a/app/services/forums_linkbuilder_service.rb
+++ b/app/services/forums_linkbuilder_service.rb
@@ -13,7 +13,7 @@ class ForumsLinkbuilderService < Service
       'Item': '/forum/items',
       'Job': '/forum/jobs',
       'Landmark': '/forum/landmarks',
-      'Language': '/forum/general-worldbuilding', # wtf did I do
+      'Language': '/forum/languages', # wtf did I do
       'Location': '/forum/locations',
       'Magic': '/forum/magic',
       'Planet': '/forum/planets',

--- a/app/views/cards/user/_recent_activity.html.erb
+++ b/app/views/cards/user/_recent_activity.html.erb
@@ -1,4 +1,4 @@
-<% if content_list.any? %>
+<% if content_list && content_list.any? %>
   <div style="margin-top: -10px;" class="recent-activity">
     <%=
       render partial: 'content/list/list',

--- a/app/views/content/display/_quick_reference.html.erb
+++ b/app/views/content/display/_quick_reference.html.erb
@@ -32,7 +32,7 @@
               <tr>
                 <td class="grey-text text-darken-1"><%= field[:label] %></td>
                 <td>
-                  <% if field[:type] == 'universe' %>
+                  <% if field[:type] == 'universe' && serialized_content.data[:universe].present? %>
                     <%= link_to serialized_content.data[:universe][:name], universe_path(field[:value]) %>
                   <% else %>
                     <%= field[:value] %>

--- a/config/attributes/building.yml
+++ b/config/attributes/building.yml
@@ -72,9 +72,6 @@
 :gallery:
   :label: Gallery
   :icon: photo_library
-:changelog:
-  :label: Changelog
-  :icon: history
 :notes:
   :label: Notes
   :icon: edit

--- a/config/attributes/character.yml
+++ b/config/attributes/character.yml
@@ -162,9 +162,6 @@
 :gallery:
   :label: Gallery
   :icon: photo_library
-:changelog:
-  :label: Changelog
-  :icon: history
 :notes:
   :label: Notes
   :icon: edit

--- a/config/attributes/condition.yml
+++ b/config/attributes/condition.yml
@@ -80,9 +80,6 @@
 :gallery:
   :label: Gallery
   :icon: photo_library
-:changelog:
-  :label: Changelog
-  :icon: history
 :notes:
   :label: Notes
   :icon: edit

--- a/config/attributes/country.yml
+++ b/config/attributes/country.yml
@@ -75,9 +75,6 @@
 :gallery:
   :label: Gallery
   :icon: photo_library
-:changelog:
-  :label: Changelog
-  :icon: history
 :notes:
   :label: Notes
   :icon: edit

--- a/config/attributes/creature.yml
+++ b/config/attributes/creature.yml
@@ -95,9 +95,6 @@
 :gallery:
   :label: Gallery
   :icon: photo_library
-:changelog:
-  :label: Changelog
-  :icon: history
 :notes:
   :label: Notes
   :icon: edit

--- a/config/attributes/deity.yml
+++ b/config/attributes/deity.yml
@@ -118,9 +118,6 @@
 :gallery:
   :label: Gallery
   :icon: photo_library
-:changelog:
-  :label: Changelog
-  :icon: history
 :notes:
   :label: Notes
   :icon: edit

--- a/config/attributes/flora.yml
+++ b/config/attributes/flora.yml
@@ -73,9 +73,6 @@
 :gallery:
   :label: Gallery
   :icon: photo_library
-:changelog:
-  :label: Changelog
-  :icon: history
 :notes:
   :label: Notes
   :icon: edit

--- a/config/attributes/government.yml
+++ b/config/attributes/government.yml
@@ -112,9 +112,6 @@
 :gallery:
   :label: Gallery
   :icon: photo_library
-:changelog:
-  :label: Changelog
-  :icon: history
 :notes:
   :label: Notes
   :icon: edit

--- a/config/attributes/group.yml
+++ b/config/attributes/group.yml
@@ -101,9 +101,6 @@
 :gallery:
   :label: Gallery
   :icon: photo_library
-:changelog:
-  :label: Changelog
-  :icon: history
 :notes:
   :label: Notes
   :icon: edit

--- a/config/attributes/item.yml
+++ b/config/attributes/item.yml
@@ -50,9 +50,6 @@
 :gallery:
   :label: Gallery
   :icon: photo_library
-:changelog:
-  :label: Changelog
-  :icon: history
 :notes:
   :label: Notes
   :icon: edit

--- a/config/attributes/job.yml
+++ b/config/attributes/job.yml
@@ -73,9 +73,6 @@
 :gallery:
   :label: Gallery
   :icon: photo_library
-:changelog:
-  :label: Changelog
-  :icon: history
 :notes:
   :label: Notes
   :icon: edit

--- a/config/attributes/landmark.yml
+++ b/config/attributes/landmark.yml
@@ -53,9 +53,6 @@
 :gallery:
   :label: Gallery
   :icon: photo_library
-:changelog:
-  :label: Changelog
-  :icon: history
 :notes:
   :label: Notes
   :icon: edit

--- a/config/attributes/language.yml
+++ b/config/attributes/language.yml
@@ -45,9 +45,6 @@
 :gallery:
   :label: Gallery
   :icon: photo_library
-:changelog:
-  :label: Changelog
-  :icon: history
 :notes:
   :label: Notes
   :icon: edit

--- a/config/attributes/location.yml
+++ b/config/attributes/location.yml
@@ -84,9 +84,6 @@
 :gallery:
   :label: Gallery
   :icon: photo_library
-:changelog:
-  :label: Changelog
-  :icon: history
 :notes:
   :label: Notes
   :icon: edit

--- a/config/attributes/magic.yml
+++ b/config/attributes/magic.yml
@@ -56,9 +56,6 @@
 :gallery:
   :label: Gallery
   :icon: photo_library
-:changelog:
-  :label: Changelog
-  :icon: history
 :notes:
   :label: Notes
   :icon: edit

--- a/config/attributes/planet.yml
+++ b/config/attributes/planet.yml
@@ -100,9 +100,6 @@
 :gallery:
   :label: Gallery
   :icon: photo_library
-:changelog:
-  :label: Changelog
-  :icon: history
 :notes:
   :label: Notes
   :icon: edit

--- a/config/attributes/race.yml
+++ b/config/attributes/race.yml
@@ -72,9 +72,6 @@
 :gallery:
   :label: Gallery
   :icon: photo_library
-:changelog:
-  :label: Changelog
-  :icon: history
 :notes:
   :label: Notes
   :icon: edit

--- a/config/attributes/religion.yml
+++ b/config/attributes/religion.yml
@@ -71,9 +71,6 @@
 :gallery:
   :label: Gallery
   :icon: photo_library
-:changelog:
-  :label: Changelog
-  :icon: history
 :notes:
   :label: Notes
   :icon: edit

--- a/config/attributes/scene.yml
+++ b/config/attributes/scene.yml
@@ -36,9 +36,6 @@
 :gallery:
   :label: Gallery
   :icon: photo_library
-:changelog:
-  :label: Changelog
-  :icon: history
 :notes:
   :label: Notes
   :icon: edit

--- a/config/attributes/technology.yml
+++ b/config/attributes/technology.yml
@@ -89,9 +89,6 @@
 :gallery:
   :label: Gallery
   :icon: photo_library
-:changelog:
-  :label: Changelog
-  :icon: history
 :notes:
   :label: Notes
   :icon: edit

--- a/config/attributes/town.yml
+++ b/config/attributes/town.yml
@@ -62,9 +62,6 @@
 :gallery:
   :label: Gallery
   :icon: photo_library
-:changelog:
-  :label: Changelog
-  :icon: history
 :notes:
   :label: Notes
   :icon: edit

--- a/config/attributes/tradition.yml
+++ b/config/attributes/tradition.yml
@@ -57,9 +57,6 @@
 :gallery:
   :label: Gallery
   :icon: photo_library
-:changelog:
-  :label: Changelog
-  :icon: history
 :notes:
   :label: Notes
   :icon: edit

--- a/config/attributes/universe.yml
+++ b/config/attributes/universe.yml
@@ -36,9 +36,6 @@
 :gallery:
   :label: Gallery
   :icon: photo_library
-:changelog:
-  :label: Changelog
-  :icon: history
 :contributors:
   :label: Contributors
   :icon: group_add

--- a/config/attributes/vehicle.yml
+++ b/config/attributes/vehicle.yml
@@ -73,9 +73,6 @@
 :gallery:
   :label: Gallery
   :icon: photo_library
-:changelog:
-  :label: Changelog
-  :icon: history
 :notes:
   :label: Notes
   :icon: edit


### PR DESCRIPTION
This snippet should be run in tandem with this release:

    Thredded::Messageboard.where(slug: 'general-worldbuilding').update(slug: 'languages')

This will break all bookmarks to the languages forum, and potentially cause some temporary errors for people who have pages open when the release goes live; any page refresh will fix the problem for every affected user.

This PR:

* Fixes a 500 that can occur around universe name fetching in quick reference cards
* Fixes a 500 that can occur on the recent content page when a user has no content at all
* Removes the changelog link from a content form's sidelinks, since it's in the navbar now
* Adds a bit of padding around the edges of the full-width design
* Fixes the "General Worldbuilding" forum linking to Languages
* Shows checkboxes that were unintentionally hidden on forums during the redesign