### PR TITLE
Editor improvements feb

### DIFF
--- a/app/assets/stylesheets/editor.css.scss
+++ b/app/assets/stylesheets/editor.css.scss
@@ -2,7 +2,7 @@
   min-height: 400px;
   border: 1px solid #dedede;
   padding: 5px 0;
-  margin-bottom: 600px;
+  margin-bottom: 60px;
 
   color: black;
 

--- a/app/assets/stylesheets/navbar.css
+++ b/app/assets/stylesheets/navbar.css
@@ -5,10 +5,10 @@
 @media only screen and (min-width: 993px) {
 	body.has-fixed-sidenav {
     padding-left: 300px !important;
-	}
 
-	nav.navbar.logged-in {
-	  width: calc(100% - 300px);
+		nav.navbar.logged-in {
+			width: calc(100% - 300px);
+		}
 	}
 }
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -6,6 +6,8 @@ class DocumentsController < ApplicationController
   before_action :set_navbar_actions, except: [:edit]
   before_action :set_footer_visibility, only: [:edit]
 
+  layout 'editor', only: [:edit]
+
   def index
     @documents = current_user.documents.order('updated_at desc')
   end

--- a/app/models/serializers/content_serializer.rb
+++ b/app/models/serializers/content_serializer.rb
@@ -60,7 +60,7 @@ class ContentSerializer
               hidden: !!field.hidden,
               position: field.position,
               old_column_source: field.old_column_source,
-              value: self.attribute_values.detect { |value|
+              value: self.attribute_values.order('created_at desc').detect { |value| #codesmell here: we shouldn't ever have multiple attribute values but for some reason we do sometimes (in collaboration?)
                 value.entity_type == content.page_type &&
                 value.entity_id   == content.id &&
                 value.attribute_field_id == field.id

--- a/app/services/api/v1/api_content_service.rb
+++ b/app/services/api/v1/api_content_service.rb
@@ -4,7 +4,7 @@ class Api::V1::ApiContentService < Service
     user = User.from_api_key(api_key)
 
     return "Error: Invalid API Key"      if user.nil?
-    return "Error: Invalid content type" if valid_content_type?(content_type)
+    return "Error: Invalid content type" unless valid_content_type?(content_type)
 
     # todo we need to serialize attributes instead of natural model columns
     user.send(content_type.downcase.pluralize).as_json

--- a/app/views/documents/components/_document_name_bar.html.erb
+++ b/app/views/documents/components/_document_name_bar.html.erb
@@ -1,18 +1,14 @@
-<div class="document-name-bar">
-  <div class="row teal lighten-1 white-text fixed">
-    <div class="col s12">
-      <% if defined?(f) %>
-        Editing
-        <div class="input-field inline">
-          <%=
-            f.text_field :title,
-              placeholder: 'Untitled document',
-              value: document.try(:name) || 'Untitled document',
-              class: 'white-text',
-              style: 'font-size: 150%; border-bottom: 1px solid white;'
-          %>
-        </div>
-      <% end %>
+<span class="document-name-bar white-text">
+  <% if defined?(f) %>
+    Editing
+    <div class="input-field inline">
+      <%=
+        f.text_field :title,
+          placeholder: 'Untitled document',
+          value: document.try(:name) || 'Untitled document',
+          class: 'white-text',
+          style: 'font-size: 150%; border-bottom: 1px solid white;'
+      %>
     </div>
-  </div>
-</div>
+  <% end %>
+</span>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -1,18 +1,20 @@
 <%= form_for @document do |f| %>
-  <%= content_for :full_width_page_header do %>
+  <%= content_for :navbar_left_content do %>
     <%= render partial: 'documents/components/document_name_bar', locals: { document: @document, f: f } %>
+  <% end %>
+
+  <%= content_for :full_width_page_header do %>
     <%= render partial: 'documents/components/autosave_bar', locals: { document: @document } %>
 
     <div class="row">
       <div class="col s12 m8 l8 offset-l1">
         <div id="editor" class="editable"><%= @document.body.try(:html_safe) %></div>
       </div>
-      <div class="col l2 m4 smart-sidebar">
+      <div class="col s12 m4 l2 smart-sidebar">
         <%= render partial: 'documents/components/smart_sidebar', locals: { document: @document } %>
       </div>
     </div>
   <% end %>
-
 
   <div class="grey-text autosave-bar">
     <i class="material-icons js-autosave-icon grey-text">save</i>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -24,7 +24,7 @@
             </p>
           </div>
           <div class="card-action nice-icon-links">
-            <%= link_to edit_document_path(document), class: 'green-text right' do %>
+            <%= link_to edit_document_path(document), class: 'green-text right', target: '_new' do %>
               <i class="material-icons"><%= Document.icon %></i> Edit
             <% end %>
             <%= link_to document_path(document), class: 'blue-text text-lighten-1' do %>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -9,7 +9,7 @@
     <div class="col l2 m4 smart-sidebar">
       <%= render partial: 'documents/components/smart_sidebar', locals: { document: @document } %>
 
-      <%= link_to edit_document_path(@document) do %>
+      <%= link_to edit_document_path(@document), target: '_new' do %>
         <div class="card <%= Document.color %>">
           <div class="card-content">
             <span class="card-title white-text">

--- a/app/views/layouts/_document_navbar.html.erb
+++ b/app/views/layouts/_document_navbar.html.erb
@@ -5,6 +5,27 @@
         <li>
           <%= yield :navbar_right_content %>
         </li>
+        <li>
+          <%=
+            link_to documents_path, class: 'tooltipped', data: {
+              position: 'left',
+              tooltip: 'Back to your documents'
+            } do
+          %>
+            <i class="material-icons white-text">file_copy</i>
+          <% end %>
+        </li>
+        <li>
+          <%=
+            link_to edit_document_path(:new), class: 'tooltipped', data: {
+              position: 'left',
+              tooltip: 'New document'
+            },
+            target: '_blank' do
+          %>
+            <i class="material-icons white-text">note_add</i>
+          <% end %>
+        </li>
       </ul>
       <ul class="left">
         <li>

--- a/app/views/layouts/_document_navbar.html.erb
+++ b/app/views/layouts/_document_navbar.html.erb
@@ -1,0 +1,21 @@
+<div class="navbar-fixed">
+  <nav class="navbar nav-extended <%= 'logged-in' if user_signed_in? %>" style="background-color: <%= @navbar_color.presence || '#2196F3' %>">
+    <div class="nav-wrapper">
+      <ul class="right">
+        <li>
+          <%= yield :navbar_right_content %>
+        </li>
+      </ul>
+      <ul class="left">
+        <li>
+          <a class="sidenav-trigger show-on-large" href="#" data-target="sidenav-left">
+            <i class="material-icons">menu</i>
+          </a>
+        </li>
+        <li>
+          <%= yield :navbar_left_content %>
+        </li>
+      </ul>
+    </div>
+  </nav>
+</div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -24,9 +24,9 @@
       <div class="col s12">
         <div class="grey-text">
           <a href="/about/privacy" class="grey-text">Privacy Policy</a> /
-          <a href="https://github.com/indentlabs/notebook" class="grey-text" target="_new">Source Code</a> /
-          <a href="https://www.twitter.com/indentlabs" class="grey-text" target="_new">Twitter</a> /
-          <a href="https://www.facebook.com/Notebookai-556092274722663/" class="grey-text" target="_new">Facebook</a>
+          <a href="https://github.com/indentlabs/notebook" class="grey-text" target="_blank">Source Code</a> /
+          <a href="https://www.twitter.com/indentlabs" class="grey-text" target="_blank">Twitter</a> /
+          <a href="https://www.facebook.com/Notebookai-556092274722663/" class="grey-text" target="_blank">Facebook</a>
         </div>
       </div>
     </div>

--- a/app/views/layouts/_sidenav.html.erb
+++ b/app/views/layouts/_sidenav.html.erb
@@ -1,4 +1,4 @@
-<ul id="sidenav-left" class="sidenav sidenav-fixed">
+<ul id="sidenav-left" class="sidenav <%= 'sidenav-fixed' unless defined?(locals) && locals.key?(:fixed) && !locals[:fixed] %>">
   <li class="blue">
     <%= link_to main_app.root_path, class: 'logo-container white-text' do %>
       <i class="material-icons white-text right">

--- a/app/views/layouts/_sidenav.html.erb
+++ b/app/views/layouts/_sidenav.html.erb
@@ -12,7 +12,7 @@
       <li class="bold waves-effect blue lighten-1 tooltipped" data-tooltip="Focus on a specific universe..." data-position="right">
         <a class="collapsible-header white-text" tabindex="0">
           <%= @universe_scope.present? ? truncate(@universe_scope.name, length: 26) : 'All Universes' %>
-          <i class="material-icons chevron">chevron_left</i>
+          <i class="material-icons chevron white-text">chevron_left</i>
         </a>
         <div class="collapsible-body blue lighten-1">
           <ul>

--- a/app/views/layouts/editor.html.erb
+++ b/app/views/layouts/editor.html.erb
@@ -1,21 +1,23 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/medium-editor/5.22.1/css/medium-editor.min.css" integrity="sha256-R45gjjgTM82XinRpA4xKOL00zJ2/ajOSjY3tvw5JaDM=" crossorigin="anonymous" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/medium-editor/5.22.1/css/themes/bootstrap.min.css" integrity="sha256-IAkbHl+TfLeobqAknNEdwDbXIW8A0Rj7GEftvOJa/LI=" crossorigin="anonymous" />
-
   <%= render 'layouts/common_head' %>
-
-  <script async src="https://cdnjs.cloudflare.com/ajax/libs/medium-editor/5.22.1/js/medium-editor.min.js" integrity="sha256-Q35a6YaW9okg2cZSdp9fcxRE33VKe3rp1mX1uf1Q85M=" crossorigin="anonymous"></script>
 </head>
-<body>
-
+<body data-in-app="true">
+  <%= render 'layouts/sidenav', locals: { fixed: false } if user_signed_in? %>
   <%= render 'layouts/navbar' %>
 
   <main>
-    <div>
+    <%= yield :full_width_page_header %>
+    <div class="container<% if (user_signed_in? && current_user.fluid_preference) || request.env['REQUEST_PATH'].start_with?('/forum/') %>-fluid<% end %>">
       <div class="row">
-        <div class="col s12 m12">
+        <div class="col s12">
+          <%= render 'cards/ui/alert' %>
+          <%= render 'cards/ui/notice' %>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col s12">
           <%= yield %>
         </div>
       </div>
@@ -23,13 +25,19 @@
 
     <%= render 'layouts/ganalytics' %>
 
-    <a href="https://plus.google.com/118076966717703203223" rel="publisher"></a>
   </main>
 
-  <%= render 'layouts/footer' %>
+  <%= render 'layouts/footer' unless defined?(@show_footer) && !@show_footer %>
+  <%= render partial: 'content/keyboard_controls_help_modal' %>
 
   <script type="text/javascript">
     <%= yield :javascript %>
+
+    $(document).ready(function() {
+      $('.tooltipped').tooltip({ enterDelay: 50 });
+      M.AutoInit();
+      $('.dropdown-trigger').dropdown({coverTrigger: false});
+    });
   </script>
 
 </body>

--- a/app/views/layouts/editor.html.erb
+++ b/app/views/layouts/editor.html.erb
@@ -5,17 +5,11 @@
 </head>
 <body data-in-app="true">
   <%= render 'layouts/sidenav', locals: { fixed: false } if user_signed_in? %>
-  <%= render 'layouts/navbar' %>
+  <%= render 'layouts/document_navbar' %>
 
-  <main>
+  <main style="padding-top: 10px;">
     <%= yield :full_width_page_header %>
-    <div class="container<% if (user_signed_in? && current_user.fluid_preference) || request.env['REQUEST_PATH'].start_with?('/forum/') %>-fluid<% end %>">
-      <div class="row">
-        <div class="col s12">
-          <%= render 'cards/ui/alert' %>
-          <%= render 'cards/ui/notice' %>
-        </div>
-      </div>
+    <div class="container-fluid">
       <div class="row">
         <div class="col s12">
           <%= yield %>

--- a/app/views/main/for_designers.html.erb
+++ b/app/views/main/for_designers.html.erb
@@ -396,7 +396,7 @@ body {
           <div class="row">
             <div class="col s3">
               <p class="light">
-                <a href='https://medium.com/indent-labs/introducing-notebook-ai-f06d8d3d8e77' target="_new">We launched Notebook.ai last
+                <a href='https://medium.com/indent-labs/introducing-notebook-ai-f06d8d3d8e77' target="_blank">We launched Notebook.ai last
                 October</a> and we've been iterating fast based on the feedback of thousands of users excited to have a smart tool for
                 their worldbuilding. While we focused primarily on authors to begin with, many users have told us we're a fantastic solution
                 for creating the rich worlds necessary for high-quality game development.

--- a/app/views/main/for_roleplayers.html.erb
+++ b/app/views/main/for_roleplayers.html.erb
@@ -401,7 +401,7 @@ body {
           <div class="row">
             <div class="col s3">
               <p class="light">
-                <a href='https://medium.com/indent-labs/introducing-notebook-ai-f06d8d3d8e77' target="_new">We launched Notebook.ai last
+                <a href='https://medium.com/indent-labs/introducing-notebook-ai-f06d8d3d8e77' target="_blank">We launched Notebook.ai last
                 October</a> and we've been iterating fast based on the feedback of thousands of users excited to have a smart tool for
                 their worldbuilding. While we focused primarily on authors to begin with, many users have told us we're a fantastic solution
                 for managing campaigns and keeping players up to date.

--- a/app/views/main/for_writers.html.erb
+++ b/app/views/main/for_writers.html.erb
@@ -394,7 +394,7 @@ body {
           <div class="row">
             <div class="col s3">
               <p class="light">
-                Until <a href='https://medium.com/indent-labs/introducing-notebook-ai-f06d8d3d8e77' target="_new">we launched Notebook.ai last October</a>,
+                Until <a href='https://medium.com/indent-labs/introducing-notebook-ai-f06d8d3d8e77' target="_blank">we launched Notebook.ai last October</a>,
                 worldbuilding was almost exclusively done with unstructured solutions like spreadsheets and personal wikis &mdash; or the good ol'
                 pen & paper.
               </p>


### PR DESCRIPTION
* Gives the document editor its own layout that hides the site sidebar by default and maximizes editor space
* Opens the document editor in its own tab
* Adds links to the editor to quickly jump back to all documents and/or create a new document
* Fixes minor perms bug around document viewing (that would have thrown 500)
* Adds WIP stats page

Unrelated:
* Fixes minor bug in the WIP API
* Updates `_new` targets to `_blank`