### PR TITLE
Add page linking to documents

### DIFF
--- a/app/assets/stylesheets/editor.css.scss
+++ b/app/assets/stylesheets/editor.css.scss
@@ -26,6 +26,10 @@
     letter-spacing: .01rem;
   }
 
+  strong.page-link-shortcode {
+    background: yellow;
+  }
+
   /* PAGES */
   background: white;
   padding: 30px;
@@ -55,7 +59,6 @@ b, strong {
 
   .card {
     opacity: 0.4;
-
     border-bottom: 5px solid #009688;
 
     &:hover {

--- a/app/assets/stylesheets/editor.css.scss
+++ b/app/assets/stylesheets/editor.css.scss
@@ -3,17 +3,33 @@
   border: 1px solid #dedede;
   padding: 5px 0;
   margin-bottom: 60px;
+  color: #222222;
 
-  color: black;
+  h2 {
+    font-size: 32px;
+  }
+
+  h3 {
+    font-size: 28px;
+  }
+
+  h4 {
+    font-size: 24px;
+  }
 
   p {
     margin-top: 0;
+
+    font-family: Georgia,Cambria,"Times New Roman",Times,serif;
+    font-size: 18px;
+    line-height: 1.5;
+    letter-spacing: .01rem;
   }
 
   /* PAGES */
   background: white;
   padding: 30px;
-  border-bottom: 1px solid grey;
+  border-bottom: 10px solid #009688;
 }
 
 /* Materialize hacks */
@@ -34,12 +50,16 @@ b, strong {
 }
 
 .smart-sidebar {
-  opacity: 0.4;
-
   position: fixed;
   right: 1% !important;
 
-  &:hover {
-    opacity: 1.0;
+  .card {
+    opacity: 0.4;
+
+    border-bottom: 5px solid #009688;
+
+    &:hover {
+      opacity: 1.0;
+    }
   }
 }

--- a/app/assets/stylesheets/editor.css.scss
+++ b/app/assets/stylesheets/editor.css.scss
@@ -36,6 +36,9 @@ b, strong {
 .smart-sidebar {
   opacity: 0.4;
 
+  position: fixed;
+  right: 1% !important;
+
   &:hover {
     opacity: 1.0;
   }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -69,4 +69,27 @@ class ApplicationController < ActionController::Base
       0
     end
   end
+
+  def populate_linkable_content_for_each_content_type
+    linkable_classes = Rails.application.config.content_types[:all].map(&:name) & current_user.user_content_type_activators.pluck(:content_type)
+    #linkable_classes -= ["Universe"]
+
+    @linkables_cache = {}
+    linkable_classes.each do |class_name|
+      # class_name = "Character"
+
+      @linkables_cache[class_name] = current_user.send("linkable_#{class_name.downcase.pluralize}")
+        .in_universe(@universe_scope)
+
+      if @content.present? && @content.persisted?
+        @linkables_cache[class_name] = @linkables_cache[class_name]
+          .in_universe(@content.universe)
+          .reject { |content| content.class.name == class_name && content.id == @content.id }
+      end
+
+      @linkables_cache[class_name] = @linkables_cache[class_name].sort_by(&:name)
+        .map { |c| [c.name, c.id] }
+        .compact
+    end
+  end
 end

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -405,29 +405,6 @@ class ContentController < ApplicationController
     TemporaryFieldMigrationService.migrate_fields_for_content(content, current_user) if content.present?
   end
 
-  def populate_linkable_content_for_each_content_type
-    linkable_classes = Rails.application.config.content_types[:all].map(&:name) & current_user.user_content_type_activators.pluck(:content_type)
-    linkable_classes -= ["Universe"]
-
-    @linkables_cache = {}
-    linkable_classes.each do |class_name|
-      # class_name = "Character"
-
-      @linkables_cache[class_name] = current_user.send("linkable_#{class_name.downcase.pluralize}")
-        .in_universe(@universe_scope)
-
-      if @content.present? && @content.persisted?
-        @linkables_cache[class_name] = @linkables_cache[class_name]
-          .in_universe(@content.universe)
-          .reject { |content| content.class.name == class_name && content.id == @content.id }
-      end
-
-      @linkables_cache[class_name] = @linkables_cache[class_name].sort_by(&:name)
-        .map { |c| [c.name, c.id] }
-        .compact
-    end
-  end
-
   def valid_content_types
     Rails.application.config.content_types[:all]
   end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -46,6 +46,7 @@ class DocumentsController < ApplicationController
   def update
     document = Document.with_deleted.find_or_initialize_by(id: params[:id], user: current_user)
 
+    # todo current_user.can_modify?(document) instead
     unless document.user == current_user
       redirect_to(dashboard_path, notice: "You don't have permission to do that!")
       return

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -6,6 +6,8 @@ class DocumentsController < ApplicationController
   before_action :set_navbar_actions, except: [:edit]
   before_action :set_footer_visibility, only: [:edit]
 
+  before_action :populate_linkable_content_for_each_content_type, only: [:edit]
+
   layout 'editor', only: [:edit]
 
   def index

--- a/app/models/content_types/universe.rb
+++ b/app/models/content_types/universe.rb
@@ -49,6 +49,10 @@ class Universe < ApplicationRecord
 
   has_many :contributors, dependent: :destroy
 
+  # Stub for when we allow universe nesting; also makes polymorphism play a bit nicer
+  scope :in_universe, ->(id = nil) { where(id: id) unless id.nil? }
+
+
   after_destroy do
     Rails.application.config.content_types[:all_non_universe].each do |content_type|
       content_type.where(universe_id: self.id).update_all(universe_id: nil)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
   include HasContent
   include Authority::UserAbilities
 
-  validates :username, 
+  validates :username,
     uniqueness: true,
     allow_nil: true,
     allow_blank: true,
@@ -77,9 +77,12 @@ class User < ApplicationRecord
     end
   end
 
-  #def linkable_universes
-    #todo
-  #end
+  def linkable_universes
+    my_universe_ids = universes.pluck(:id)
+    contributable_universe_ids = contributable_universes.pluck(:id)
+
+    Universe.where(id: my_universe_ids + contributable_universe_ids)
+  end
 
   has_many :documents, dependent: :destroy
 

--- a/app/views/documents/components/_smart_sidebar.html.erb
+++ b/app/views/documents/components/_smart_sidebar.html.erb
@@ -6,7 +6,10 @@
         <i class="material-icons right activator" style="cursor: pointer">settings</i>
       </span>
       <ul>
-        <li>&middot; Written by <%= link_to @document.user.name, @document.user %>
+        <li>
+          <i class="material-icons grey-text">edit</i>
+          Written by <%= link_to @document.user.name, @document.user %>
+        </li>
         <!--
         <li>
           &middot; Visibility:
@@ -39,6 +42,51 @@
           <% end %>
         </li>
       </ul>
+    </div>
+  </div>
+
+  <div class="card blue-grey lighten-4">
+    <div class="card-content">
+      <span class="card-title grey-text text-darken-4">
+        Insert page link
+        <span class="grey-text" style="padding-top: 6px; padding-right: 4px;">
+          (<a href="#" class="tooltipped" tabindex="-1" data-tooltip="These links will insert a small snippet that<br />automatically turns into a link to that page after saving." data-position="bottom" data-html="true">?</a>)
+        </span>
+      </span>
+      <div class="document-link-bar">
+        <div class="btn-group" role="group">
+
+          <% @linkables_cache.keys.each do |class_name| %>
+            <% relation_class = class_name.constantize %>
+            <a class="btn btn-small <%= relation_class.color %> dropdown-trigger <%= 'disabled' unless @linkables_cache.fetch(class_name, []).any? %> tooltipped"
+               href="#" style="padding: 0 9px;"
+               data-target='active_link_bar_<%= class_name %>'
+               data-tooltip="<%= class_name.pluralize %>"
+               data-position="bottom"
+               tabindex="-1">
+              <i class="material-icons">
+                <%= relation_class.icon %>
+              </i>
+            </a>
+
+            <ul id='active_link_bar_<%= class_name %>' class='dropdown-content'>
+              <%
+                @linkables_cache[class_name].each do |linkable|
+              %>
+                <li>
+                  <a href="#" data-content-type="<%= class_name %>" data-content-id="<%= linkable.second %>" class="js-content-link-option">
+                    <i class="material-icons <%= relation_class.color %>-text"><%= relation_class.icon %></i>
+                    <%= linkable.first %>
+                  </a>
+                </li>
+              <%
+              end
+              %>
+            </ul>
+
+          <% end %>
+        </div>
+      </div>
     </div>
   </div>
 <% end %>

--- a/app/views/documents/components/_smart_sidebar.html.erb
+++ b/app/views/documents/components/_smart_sidebar.html.erb
@@ -7,7 +7,7 @@
       </span>
       <ul>
         <li>
-          <i class="material-icons grey-text">edit</i>
+          <i class="material-icons grey-text tiny">edit</i>
           Written by <%= link_to @document.user.name, @document.user %>
         </li>
         <!--
@@ -16,8 +16,14 @@
           <a href="#" class="tooltipped" data-tooltip="Sharing documents is coming soon.">Private</a>
         </li>
         -->
-        <li>&middot; Created <%= time_ago_in_words @document.created_at %> ago</li>
-        <li>&middot; Last edited <%= time_ago_in_words @document.updated_at %> ago</li>
+        <li>
+          <i class="material-icons grey-text tiny">av_timer</i>
+          Created <%= time_ago_in_words @document.created_at %> ago
+        </li>
+        <li>
+          <i class="material-icons grey-text tiny">av_timer</i>
+          Last edited <%= time_ago_in_words @document.updated_at %> ago
+        </li>
       </ul>
       <p class="blue-text">
         This card is only visible to you.

--- a/app/views/documents/components/_smart_sidebar.html.erb
+++ b/app/views/documents/components/_smart_sidebar.html.erb
@@ -60,6 +60,7 @@
         <div class="btn-group" role="group">
 
           <% @linkables_cache.keys.each do |class_name| %>
+            <% next unless @linkables_cache.fetch(class_name, []).any? %>
             <% relation_class = class_name.constantize %>
             <a class="btn btn-small <%= relation_class.color %> dropdown-trigger <%= 'disabled' unless @linkables_cache.fetch(class_name, []).any? %> tooltipped"
                href="#" style="padding: 0 9px;"

--- a/app/views/documents/components/_smart_sidebar.html.erb
+++ b/app/views/documents/components/_smart_sidebar.html.erb
@@ -25,9 +25,6 @@
           Last edited <%= time_ago_in_words @document.updated_at %> ago
         </li>
       </ul>
-      <p class="blue-text">
-        This card is only visible to you.
-      </p>
     </div>
     <div class="card-reveal">
       <span class="card-title grey-text text-darken-4">

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -169,4 +169,22 @@
     }
   });
 
+  $('.js-content-link-option').click(function (click_event) {
+    var selected_option    = $(click_event.target);
+    var document_editor    = editor;
+
+    var token_to_insert = [
+      '[[',
+      selected_option.data('content-type'),
+      '-',
+      selected_option.data('content-id'),
+      ']]'
+    ].join('');
+
+    editor.cleanPaste(token_to_insert);
+    // Don't jump to the top of the page after clicking!
+    click_event.stopPropagation();
+    return false;
+  });
+
 <% end %>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -92,7 +92,8 @@
         text: 'Write as little or as much as you want!'
     },
     paste: {
-      forcePlainText: false
+      forcePlainText: false,
+      cleanAttrs: ['style', 'dir'],
     }
   });
 
@@ -174,14 +175,25 @@
     var document_editor    = editor;
 
     var token_to_insert = [
+      '<strong class="page-link-shortcode">',
       '[[',
       selected_option.data('content-type'),
       '-',
       selected_option.data('content-id'),
-      ']] '
+      ']]',
+      '</strong>',
+      '&nbsp;'
     ].join('');
+    console.log("Inserting " + token_to_insert);
 
-    editor.cleanPaste(token_to_insert);
+    // If the editor isn't focused, we need to focus it before pasting
+    if (!editor.getFocusedElement()) {
+      $('#editor').trigger('click');
+    } else {
+      // Paste to the end of the document
+    }
+
+    editor.pasteHTML(token_to_insert);
 
     // Don't jump to the top of the page after clicking!
     click_event.stopPropagation();

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -7,10 +7,10 @@
     <%= render partial: 'documents/components/autosave_bar', locals: { document: @document } %>
 
     <div class="row">
-      <div class="col s12 m8 l8 offset-l1">
+      <div class="col s12 m8 l6 offset-l2">
         <div id="editor" class="editable"><%= @document.body.try(:html_safe) %></div>
       </div>
-      <div class="col s12 m4 l2 smart-sidebar hide-on-small-only">
+      <div class="col s12 m4 l3 smart-sidebar hide-on-small-only">
         <%= render partial: 'documents/components/smart_sidebar', locals: { document: @document } %>
       </div>
     </div>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -178,10 +178,11 @@
       selected_option.data('content-type'),
       '-',
       selected_option.data('content-id'),
-      ']]'
+      ']] '
     ].join('');
 
     editor.cleanPaste(token_to_insert);
+
     // Don't jump to the top of the page after clicking!
     click_event.stopPropagation();
     return false;

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -10,7 +10,7 @@
       <div class="col s12 m8 l8 offset-l1">
         <div id="editor" class="editable"><%= @document.body.try(:html_safe) %></div>
       </div>
-      <div class="col s12 m4 l2 smart-sidebar">
+      <div class="col s12 m4 l2 smart-sidebar hide-on-small-only">
         <%= render partial: 'documents/components/smart_sidebar', locals: { document: @document } %>
       </div>
     </div>


### PR DESCRIPTION
This restyles the document sidebar slightly and adds page linking similar to the page linking on content fields. Clicking a page from any of the dropdowns adds its quicklink code to the current caret position.

![2019-03-25-211830_737x561_scrot](https://user-images.githubusercontent.com/538235/54966947-d7985a80-4f43-11e9-986f-dbae48699a00.png)

It's a little fiddly because of the issue described in https://github.com/yabwe/medium-editor/issues/1499, but hopefully someone over there sheds some insight on why this is the case or suggests something alternative.

c.f. #336 