### PR TITLE
Apr 9 changes

### DIFF
--- a/app/authorizers/document_authorizer.rb
+++ b/app/authorizers/document_authorizer.rb
@@ -1,4 +1,8 @@
 class DocumentAuthorizer < ApplicationAuthorizer
+  def self.creatable_by?(user)
+    true
+  end
+
   def readable_by?(user)
     [
       resource.user_id == user.id

--- a/app/services/content_formatter_service.rb
+++ b/app/services/content_formatter_service.rb
@@ -100,7 +100,7 @@ class ContentFormatterService < Service
   def self.link_for(content_model)
     [
       Rails.env.production? ? 'https://' : 'http://',
-      'www.notebook.ai', # Rails.application.routes.default_url_options[:host],
+      Rails.env.production? ? 'www.notebook.ai' : 'localhost:3000', # Rails.application.routes.default_url_options[:host]?
       '/plan/',
       content_model.class.name.downcase.pluralize,
       '/',

--- a/app/views/content/components/_list_filter_bar.html.erb
+++ b/app/views/content/components/_list_filter_bar.html.erb
@@ -118,7 +118,7 @@
 
       &nbsp;
 
-      <div class="input-field inline" style="position: relative; top: 5px;">
+      <div class="input-field inline" style="position: relative; top: 5px; min-width: 320px">
         <input id="js-content-name-filter" type="text">
         <label for="js-content-name-filter">Filter <%= content_type.name.downcase.pluralize %> by name...</label>
       </div>


### PR DESCRIPTION
* Adds a Document permission that was missing (resulting in a false "You need Premium to create more Document pages" on documents#index)
* Widens the filter bar name field input so the placeholder doesn't wrap on small / zoomed screens
* Defaults image uploads to `localhost` when the server is in development mode
* Adds a "Create another X" quicklink under sidelinks on content#show pages