### PR TITLE
April 10 changes

### DIFF
--- a/app/assets/stylesheets/layers.scss
+++ b/app/assets/stylesheets/layers.scss
@@ -7,3 +7,8 @@
 .slider .slides li.active {
   z-index: 1 !important;
 }
+
+.slider {
+  height: 140px;
+  overflow: hidden;
+}

--- a/app/views/content/edit.html.erb
+++ b/app/views/content/edit.html.erb
@@ -35,7 +35,7 @@
           <% linkable_class = class_name.constantize %>
           <% collection.each do |page_name, page_id| %>
             {
-              key:   "<%= page_name.gsub('"', "\"") %>",
+              key:   "<%= page_name.gsub('"', "\"").gsub("\n", " ").gsub("\r", " ").strip %>",
               value: '[[<%= class_name %>-<%= page_id %>]]',
               color: '<%= linkable_class.color %>',
               icon:  '<%= linkable_class.icon %>'

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -176,7 +176,7 @@
           <% linkable_class = class_name.constantize %>
           <% collection.each do |page_name, page_id| %>
             {
-              key:   "<%= page_name.gsub('"', "\"") %>",
+              key:   "<%= page_name.gsub('"', "\"").gsub("\n", " ").gsub("\r", " ").strip %>",
               value: '[[<%= class_name %>-<%= page_id %>]]',
               color: '<%= linkable_class.color %>',
               icon:  '<%= linkable_class.icon %>'

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -4,7 +4,7 @@
 
   <div class="row">
     <div class="col s12 m8 l8 offset-l1">
-      <div id="editor"><%= ContentFormatterService.substitute_content_links(@document.body.try(:html_safe), current_user).html_safe %></div>
+      <div id="editor"><%= ContentFormatterService.substitute_content_links(@document.body.try(:html_safe) || "", current_user).html_safe %></div>
     </div>
     <div class="col l2 m4 smart-sidebar">
       <%= render partial: 'documents/components/smart_sidebar', locals: { document: @document } %>


### PR DESCRIPTION
* Fixes @mentions for people who have pages with names that span multiple lines
* Fixes a 500 for viewing blank documents
* Prevents sliders from overlapping forms on page load or when js breaks