### PR TITLE
Add a quick create another button to content#show pages

### DIFF
--- a/app/views/content/show.html.erb
+++ b/app/views/content/show.html.erb
@@ -27,6 +27,17 @@
 
   <div class="col s3">
     <%= render partial: 'content/display/sidelinks', locals: { content: @serialized_content } %>
+
+    <% if user_signed_in? && current_user.can_create?(@serialized_content.raw_model.class) %>
+      <%= link_to new_polymorphic_path(@serialized_content.raw_model.class) do %>
+        <div class="<%= @serialized_content.class_color %> card">
+          <div class="card-content white-text">
+            <i class="right material-icons">arrow_forward</i>
+            Create another <%= @serialized_content.class_name.downcase %>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
   </div>
 </div>
 


### PR DESCRIPTION
This somehow got left out of #349 or #354, so I just cherry-picked the commit over.

![2019-04-10-144442_621x577_scrot](https://user-images.githubusercontent.com/538235/55908499-3b0ac500-5b9f-11e9-9da4-4679d8939790.png)
