### PR TITLE
fix error after deleting+restoring universe

### DIFF
--- a/app/services/permission_service.rb
+++ b/app/services/permission_service.rb
@@ -31,7 +31,7 @@ class PermissionService < Service
   end
 
   def self.content_has_no_containing_universe?(content:)
-    content.universe_field_value.nil?
+    content.universe.nil?
   end
 
   def self.user_is_on_premium_plan?(user:)


### PR DESCRIPTION
1. user adds content to a universe
2. user deletes that universe
3. user restores that universe
4. content in that universe now has a nil `universe` but not nil `universe_field_value`