### PR TITLE
Finish upgrading Ruby to 2.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby "~> 2.5"
+ruby "~> 2.6"
 
 gem 'rails', '~> 5.2'
 gem 'puma', '~> 3.12'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1352,7 +1352,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.5.1p57
+   ruby 2.6.3p62
 
 BUNDLED WITH
    1.17.3

--- a/README.rdoc
+++ b/README.rdoc
@@ -35,9 +35,9 @@ TL;DR Milestones are independent of each other -- work on whatever you want to s
 
 == Installing the notebook development stack locally
 
-Install ruby 2.5.1 (using `rbenv`, `rvm`, any other Ruby version manager, or just plain ol' ruby)
+Install ruby 2.6.3 (using `rbenv`, `rvm`, any other Ruby version manager, or just plain ol' ruby)
 
-    rbenv install 2.5.1
+    rbenv install 2.6.3
 
 Install necessary libraries
 


### PR DESCRIPTION
We already upgraded Ruby to 2.6 in the `.ruby-version`, but we didn't update the Gemfile or README for new devs. This fixes that.