### PR TITLE
Remove unused index

### DIFF
--- a/db/migrate/20191113221411_remove_global_users_email_index.rb
+++ b/db/migrate/20191113221411_remove_global_users_email_index.rb
@@ -1,0 +1,7 @@
+class RemoveGlobalUsersEmailIndex < ActiveRecord::Migration[5.2]
+  def change
+    # Since we default_scope to deleted_at:nil for all User lookups, we index [email, deleted_at] now
+    # and this index is no longer needed.
+    remove_index :users, name: "index_users_on_email"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_17_191955) do
+ActiveRecord::Schema.define(version: 2019_11_13_221411) do
 
   create_table "api_keys", force: :cascade do |t|
     t.integer "user_id"
@@ -2596,7 +2596,6 @@ ActiveRecord::Schema.define(version: 2019_10_17_191955) do
     t.date "birthday"
     t.index ["deleted_at", "username"], name: "index_users_on_deleted_at_and_username"
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
-    t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["id", "deleted_at"], name: "index_users_on_id_and_deleted_at"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true


### PR DESCRIPTION
Since we `default_scope` to `deleted_at:nil` for all User lookups, we index [email, deleted_at] now, and this index is no longer needed.