### PR TITLE
Follow up to theme_color value change

### DIFF
--- a/app/views/layouts/_favicon.html.erb
+++ b/app/views/layouts/_favicon.html.erb
@@ -17,4 +17,4 @@
 <meta name="application-name" content="Notebook">
 <meta name="msapplication-TileColor" content="#2b5797">
 <meta name="msapplication-TileImage" content="/mstile-144x144.png">
-<meta name="theme-color" content="#ffffff">
+<meta name="theme-color" content="#2196F3">


### PR DESCRIPTION
Follow up to #684 because I realized that in addition to modifying `manifest.json`, the `<meta name="theme-color">` value needed an update too in order for it to work properly.

@indentlabs/contributors
