### PR TITLE
Add undeletable flags on Thredded tables

### DIFF
--- a/config/initializers/thredded.rb
+++ b/config/initializers/thredded.rb
@@ -246,10 +246,19 @@ Rails.application.config.to_prepare do
 end
 
 require 'extensions/thredded/topic'
+require 'extensions/thredded/post'
+
 Rails.application.config.to_prepare do
   begin
     if ActiveRecord::Base.connection.table_exists?(:thredded_topics)
       Thredded::Topic.include(Extensions::Thredded::Topic)
+    end
+  rescue ActiveRecord::NoDatabaseError
+  end
+
+  begin
+    if ActiveRecord::Base.connection.table_exists?(:thredded_posts)
+      Thredded::Post.include(Extensions::Thredded::Post)
     end
   rescue ActiveRecord::NoDatabaseError
   end

--- a/db/migrate/20210308072329_add_deleted_at_date_times_to_thredded_tables.rb
+++ b/db/migrate/20210308072329_add_deleted_at_date_times_to_thredded_tables.rb
@@ -1,0 +1,14 @@
+class AddDeletedAtDateTimesToThreddedTables < ActiveRecord::Migration[6.0]
+  def change
+    add_column :thredded_topics, :deleted_at, :datetime
+    add_index :thredded_topics, :deleted_at
+    add_index :thredded_topics, [:deleted_at, :messageboard_id]
+    add_index :thredded_topics, [:deleted_at, :user_id]
+
+    add_column :thredded_posts, :deleted_at, :datetime
+    add_index :thredded_posts, :deleted_at
+    add_index :thredded_posts, [:deleted_at, :messageboard_id]
+    add_index :thredded_posts, [:deleted_at, :postable_id]
+    add_index :thredded_posts, [:deleted_at, :user_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_19_080418) do
+ActiveRecord::Schema.define(version: 2021_03_08_072329) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -1187,6 +1187,7 @@ ActiveRecord::Schema.define(version: 2020_10_19_080418) do
     t.text "notes_text"
     t.index ["universe_id", "deleted_at"], name: "index_documents_on_universe_id_and_deleted_at"
     t.index ["universe_id"], name: "index_documents_on_universe_id"
+    t.index ["user_id", "deleted_at"], name: "index_documents_on_user_id_and_deleted_at"
     t.index ["user_id"], name: "index_documents_on_user_id"
   end
 
@@ -2367,7 +2368,7 @@ ActiveRecord::Schema.define(version: 2020_10_19_080418) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "description"
-    t.boolean "allow_submissions", default: false
+    t.boolean "allow_submissions"
     t.string "slug"
     t.datetime "deleted_at"
     t.index ["user_id"], name: "index_page_collections_on_user_id"
@@ -2832,7 +2833,7 @@ ActiveRecord::Schema.define(version: 2020_10_19_080418) do
   end
 
   create_table "share_comments", force: :cascade do |t|
-    t.integer "user_id"
+    t.integer "user_id", null: false
     t.integer "content_page_share_id", null: false
     t.string "message"
     t.datetime "deleted_at"
@@ -3135,6 +3136,11 @@ ActiveRecord::Schema.define(version: 2020_10_19_080418) do
     t.integer "moderation_state", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
+    t.index ["deleted_at", "messageboard_id"], name: "index_thredded_posts_on_deleted_at_and_messageboard_id"
+    t.index ["deleted_at", "postable_id"], name: "index_thredded_posts_on_deleted_at_and_postable_id"
+    t.index ["deleted_at", "user_id"], name: "index_thredded_posts_on_deleted_at_and_user_id"
+    t.index ["deleted_at"], name: "index_thredded_posts_on_deleted_at"
     t.index ["messageboard_id"], name: "index_thredded_posts_on_messageboard_id"
     t.index ["moderation_state", "updated_at"], name: "index_thredded_posts_for_display"
     t.index ["postable_id"], name: "index_thredded_posts_on_postable_id"
@@ -3196,6 +3202,10 @@ ActiveRecord::Schema.define(version: 2020_10_19_080418) do
     t.datetime "last_post_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
+    t.index ["deleted_at", "messageboard_id"], name: "index_thredded_topics_on_deleted_at_and_messageboard_id"
+    t.index ["deleted_at", "user_id"], name: "index_thredded_topics_on_deleted_at_and_user_id"
+    t.index ["deleted_at"], name: "index_thredded_topics_on_deleted_at"
     t.index ["hash_id"], name: "index_thredded_topics_on_hash_id"
     t.index ["last_post_at"], name: "index_thredded_topics_on_last_post_at"
     t.index ["messageboard_id"], name: "index_thredded_topics_on_messageboard_id"

--- a/lib/extensions/thredded/post.rb
+++ b/lib/extensions/thredded/post.rb
@@ -1,0 +1,14 @@
+# lib/extensions/thredded/post.rb
+# frozen_string_literal: true
+
+module Extensions
+  module Thredded
+    module Post
+      extend ActiveSupport::Concern
+      
+      included do
+        acts_as_paranoid
+      end
+    end
+  end
+end

--- a/lib/extensions/thredded/topic.rb
+++ b/lib/extensions/thredded/topic.rb
@@ -10,6 +10,8 @@ module Extensions
         after_create :create_content_page_share
         has_many     :content_page_shares, as: :content
 
+        acts_as_paranoid
+
         def self.icon
           'forum'
         end


### PR DESCRIPTION
We get way too many requests for me to recover old forum topics/posts, which requires me to restore an old snapshot of the database from Heroku and poke through it manually (and remember to immediately delete it after, so we don't get charged a few extra hundred bucks!).

This PR adds `acts_as_paranoid` functionality to `Thredded::Topic` and `Thredded::Post`. I also added some DB indices that mirror most of the existing ones but incorporate `deleted_at`. If this causes performance problems in production, we can go ahead and disable `acts_as_paranoid` in the lib extenders until we figure out how to fix it (likely: what other indices we need).