### PR TITLE
Attempting to fix file uploads without upgrading to 6.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'aws-sdk-s3'
 gem 'filesize'
 
 # Image processing
-gem 'paperclip'
+gem 'paperclip' # used in ImageUpload until we migrate to ActiveStorage
 gem 'rmagick'
 gem 'image_processing'
 gem 'active_storage_validations'

--- a/bin/setup
+++ b/bin/setup
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 require 'fileutils'
-include FileUtils
 
 # path to your application root.
 APP_ROOT = File.expand_path('..', __dir__)
@@ -9,24 +8,25 @@ def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
 end
 
-chdir APP_ROOT do
-  # This script is a starting point to setup your application.
+FileUtils.chdir APP_ROOT do
+  # This script is a way to setup or update your development environment automatically.
+  # This script is idempotent, so that you can run it at anytime and get an expectable outcome.
   # Add necessary setup steps to this file.
 
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
 
-  # Install JavaScript dependencies if using Yarn
+  # Install JavaScript dependencies
   # system('bin/yarn')
 
   # puts "\n== Copying sample files =="
   # unless File.exist?('config/database.yml')
-  #   cp 'config/database.yml.sample', 'config/database.yml'
+  #   FileUtils.cp 'config/database.yml.sample', 'config/database.yml'
   # end
 
   puts "\n== Preparing database =="
-  system! 'bin/rails db:setup'
+  system! 'bin/rails db:prepare'
 
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,3 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
-require 'bundler/setup'  # Set up gems listed in the Gemfile.
-# require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+require 'bundler/setup' # Set up gems listed in the Gemfile.

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -2,7 +2,7 @@ development:
   adapter: async
 
 test:
-  adapter: async
+  adapter: test
 
 production:
   adapter: redis

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -62,11 +62,13 @@ Rails.application.configure do
   # Set test-mode Stripe API key
   Stripe.api_key = "sk_test_v37uWbseyPct6PpsfjTa3y1l"
   config.stripe_publishable_key = 'pk_test_eXI4iyJ2gR9UOGJyJERvDlHF'
+  # Todo: uhh, this pk shouldn't be here
 
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
   config.active_job.default_url_options    = { host: 'localhost', port: 3000 }
 
   # Paperclip config for image uploads
+  # TODO: we don't use paperclip anymore so this can probably go bye-bye
   config.paperclip_defaults = {
     storage: :s3,
     s3_credentials: {

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,12 +12,3 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
-
-# Include Rails helpers in the assets pipeline
-# This might be helpful for including e.g. link_to in js components, but is commented out until needed
-# Rails.application.config.assets.configure do |env|
-#   env.context_class.class_eval do
-#     include ActionView::Helpers
-#     include Rails.application.routes.url_helpers
-#   end
-# end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -11,6 +11,8 @@
 #   policy.object_src  :none
 #   policy.script_src  :self, :https
 #   policy.style_src   :self, :https
+#   # If you are using webpack-dev-server then specify webpack-dev-server host
+#   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
 
 #   # Specify URI for violation reports
 #   # policy.report_uri "/csp-violation-report-endpoint"
@@ -18,6 +20,9 @@
 
 # If you are using UJS then enable automatic nonce generation
 # Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
+
+# Set the nonce only to specific directives
+# Rails.application.config.content_security_policy_nonce_directives = %w(script-src)
 
 # Report CSP violations to a specified URI
 # For further information see the following documentation:

--- a/config/initializers/new_framework_defaults_6_0.rb
+++ b/config/initializers/new_framework_defaults_6_0.rb
@@ -1,0 +1,45 @@
+# Be sure to restart your server when you modify this file.
+#
+# This file contains migration options to ease your Rails 6.0 upgrade.
+#
+# Once upgraded flip defaults one by one to migrate to the new default.
+#
+# Read the Guide for Upgrading Ruby on Rails for more info on each option.
+
+# Don't force requests from old versions of IE to be UTF-8 encoded.
+# Rails.application.config.action_view.default_enforce_utf8 = false
+
+# Embed purpose and expiry metadata inside signed and encrypted
+# cookies for increased security.
+#
+# This option is not backwards compatible with earlier Rails versions.
+# It's best enabled when your entire app is migrated and stable on 6.0.
+# Rails.application.config.action_dispatch.use_cookies_with_metadata = true
+
+# Change the return value of `ActionDispatch::Response#content_type` to Content-Type header without modification.
+# Rails.application.config.action_dispatch.return_only_media_type_on_content_type = false
+
+# Return false instead of self when enqueuing is aborted from a callback.
+# Rails.application.config.active_job.return_false_on_aborted_enqueue = true
+
+# Send Active Storage analysis and purge jobs to dedicated queues.
+# Rails.application.config.active_storage.queues.analysis = :active_storage_analysis
+# Rails.application.config.active_storage.queues.purge    = :active_storage_purge
+
+# When assigning to a collection of attachments declared via `has_many_attached`, replace existing
+# attachments instead of appending. Use #attach to add new attachments without replacing existing ones.
+# Rails.application.config.active_storage.replace_on_assign_to_many = true
+
+# Use ActionMailer::MailDeliveryJob for sending parameterized and normal mail.
+#
+# The default delivery jobs (ActionMailer::Parameterized::DeliveryJob, ActionMailer::DeliveryJob),
+# will be removed in Rails 6.1. This setting is not backwards compatible with earlier Rails versions.
+# If you send mail in the background, job workers need to have a copy of
+# MailDeliveryJob to ensure all delivery jobs are processed properly.
+# Make sure your entire app is migrated and stable on 6.0 before using this setting.
+# Rails.application.config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
+
+# Enable the same cache key to be reused when the object being cached of type
+# `ActiveRecord::Relation` changes by moving the volatile information (max updated at and count)
+# of the relation's cache key into the cache version to support recycling cache key.
+# Rails.application.config.active_record.collection_cache_versioning = true

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,13 +1,12 @@
-require 'puma/plugin/heroku'
-
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.
 # Any libraries that use thread pools should be configured to match
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
-threads threads_count, threads_count
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
+threads min_threads_count, max_threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
@@ -17,8 +16,11 @@ port        ENV.fetch("PORT") { 3000 }
 #
 environment ENV.fetch("RAILS_ENV") { "development" }
 
+# Specifies the `pidfile` that Puma will use.
+pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+
 # Specifies the number of `workers` to boot in clustered mode.
-# Workers are forked webserver processes. If using threads and workers together
+# Workers are forked web server processes. If using threads and workers together
 # the concurrency of the application would be max `threads` * `workers`.
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
@@ -30,14 +32,10 @@ workers ENV.fetch("WEB_CONCURRENCY") { 1 }
 # before forking the application. This takes advantage of Copy On Write
 # process behavior so workers use less memory.
 #
-# preload_app!
+preload_app!
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
-
-# We preload app to save on memory usage with Copy On Write
-# https://blog.heroku.com/matz_highlights_ruby_2_0_at_waza#speed
-preload_app!
 
 on_worker_boot do
   # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot

--- a/db/migrate/20210827071633_add_foreign_key_constraint_to_active_storage_attachments_for_blob_id.active_storage.rb
+++ b/db/migrate/20210827071633_add_foreign_key_constraint_to_active_storage_attachments_for_blob_id.active_storage.rb
@@ -1,0 +1,10 @@
+# This migration comes from active_storage (originally 20180723000244)
+class AddForeignKeyConstraintToActiveStorageAttachmentsForBlobId < ActiveRecord::Migration[6.0]
+  def up
+    return if foreign_key_exists?(:active_storage_attachments, column: :blob_id)
+
+    if table_exists?(:active_storage_blobs)
+      add_foreign_key :active_storage_attachments, :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/migrate/20210827080837_add_service_name_to_active_storage_blobs.rb
+++ b/db/migrate/20210827080837_add_service_name_to_active_storage_blobs.rb
@@ -1,0 +1,17 @@
+class AddServiceNameToActiveStorageBlobs < ActiveRecord::Migration[6.0]
+  def up
+    unless column_exists?(:active_storage_blobs, :service_name)
+      add_column :active_storage_blobs, :service_name, :string
+
+      if configured_service = ActiveStorage::Blob.service.name
+        ActiveStorage::Blob.unscoped.update_all(service_name: configured_service)
+      end
+
+      change_column :active_storage_blobs, :service_name, :string, null: false
+    end
+  end
+
+  def down
+    remove_column :active_storage_blobs, :service_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_05_005416) do
+ActiveRecord::Schema.define(version: 2021_08_27_071633) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -27,10 +27,17 @@ ActiveRecord::Schema.define(version: 2021_07_05_005416) do
     t.string "filename", null: false
     t.string "content_type"
     t.text "metadata"
-    t.bigint "byte_size", null: false
+    t.integer "byte_size", null: false
     t.string "checksum", null: false
     t.datetime "created_at", null: false
+    t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
   create_table "api_keys", force: :cascade do |t|
@@ -3637,6 +3644,7 @@ ActiveRecord::Schema.define(version: 2021_07_05_005416) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "api_keys", "users"
   add_foreign_key "api_requests", "application_integrations"
   add_foreign_key "api_requests", "integration_authorizations"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_27_071633) do
+ActiveRecord::Schema.define(version: 2021_08_27_080837) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false


### PR DESCRIPTION
Grabbing what I can from `rails app:update` while still on 6.0.3.4 to try to fix [file uploads](https://one.newrelic.com/launcher/nr1-core.explorer?platform[accountId]=1783241&platform[timeRange][duration]=43200000&platformVersion=release-3045&env=production&pane=eyJiYXJjaGFydCI6ImJhcmNoYXJ0IiwidG9wRmFjZXQiOiJ0cmFuc2FjdGlvblVpTmFtZSIsInBhZ2UiOiJzaG93IiwicHJpbWFyeUZhY2V0IjoiZXJyb3IuY2xhc3MiLCJ0cmFjZUlkIjoiZTM3MGNmY2ItMDcwOC0xMWVjLWE0ZDctMDI0MmFjMTEwMDAyXzBfNzc0NyIsIm5lcmRsZXRJZCI6ImVycm9ycy11aS5vdmVydmlldyIsImVudGl0eUd1aWQiOiJNVGM0TXpJME1YeEJVRTE4UVZCUVRFbERRVlJKVDA1OE9UVXlOVEUxTWpFNSJ9&sidebars[0]=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwiZW50aXR5R3VpZCI6Ik1UYzRNekkwTVh4QlVFMThRVkJRVEVsRFFWUkpUMDU4T1RVeU5URTFNakU1Iiwic2VsZWN0ZWROZXJkbGV0Ijp7Im5lcmRsZXRJZCI6ImVycm9ycy11aS5vdmVydmlldyJ9fQ) until we can close #893.

>ActiveRecord::NotNullViolation: PG::NotNullViolation: ERROR:  null value in column "service_name" violates not-null constraintDETAIL:  Failing row contains (30984, qlf91kjkir1lihmhmdqlf4ck5cfl, image.gif, image/gif, {"identified":true}, 9302, n+77QWYvQ/JeXG5rrUyN1w==, 2021-08-27 07:31:44.978173, null).

Probably need to double-check this diff (rough merge), but it doesn't seem to even solve the problem so it's mostly just a push-for-the-progress WIP to work from.

FWIW, this seems to only affect user avatar uploads (which use ActiveStorage's `has_one_attached`) and not image uploads to notebook pages (which use paperclip's `has_attached_file`).