### PR TITLE
Fix content scoping regressions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -196,7 +196,7 @@ class ApplicationController < ActionController::Base
 
         # If we're scoped to a universe, also scope contributor content pulled to that
         # universe. If we're not, leave it as all contributor content.
-        if @universe_scope
+        if @universe_scope && pages_to_add.klass.respond_to?(:universe)
           pages_to_add = pages_to_add.where(universe: @universe_scope)
         end
 


### PR DESCRIPTION
This makes a couple changes:

* [Regression] We cache contributor pages in the linkables cache again all the time, not just when _not_ scoped to a universe
* [Optimization] The contributor page query excludes the current user's content
* [Optimization] If we _are_ scoped to a universe, only include contributor pages for that universe