### PR TITLE
Cache page words counts on each worldbuilding page (includes data migration)

### DIFF
--- a/app/jobs/cache_attribute_word_count_job.rb
+++ b/app/jobs/cache_attribute_word_count_job.rb
@@ -7,7 +7,7 @@ class CacheAttributeWordCountJob < ApplicationJob
 
     # If we have a blank/null value, ezpz 0 words
     if attribute.nil? || attribute.value.nil? || attribute.value.blank?
-      attribute.update!(word_count_cache: 0)
+      attribute.update_column(:word_count_cache, 0)
       return
     end
 
@@ -29,6 +29,6 @@ class CacheAttributeWordCountJob < ApplicationJob
       stray_punctuation: 'ignore'
     ).count(attribute.value)
 
-    attribute.update!(word_count_cache: word_count)
+    attribute.update_column(:word_count_cache, word_count)
   end
 end

--- a/app/jobs/cache_attribute_word_count_job.rb
+++ b/app/jobs/cache_attribute_word_count_job.rb
@@ -5,9 +5,13 @@ class CacheAttributeWordCountJob < ApplicationJob
     attribute_id = args.shift
     attribute    = Attribute.find_by(id: attribute_id)
 
-    return if attribute.nil?
-    return if attribute.value.nil? || attribute.value.blank?
+    # If we have a blank/null value, ezpz 0 words
+    if attribute.nil? || attribute.value.nil? || attribute.value.blank?
+      attribute.update!(word_count_cache: 0)
+      return
+    end
 
+    # If we actually have some content, use a smart WordCountAnalyzer instead of just splitting on spaces
     word_count = WordCountAnalyzer::Counter.new(
       ellipsis:          'no_special_treatment',
       hyperlink:         'count_as_one',

--- a/app/jobs/cache_sum_attribute_word_count_job.rb
+++ b/app/jobs/cache_sum_attribute_word_count_job.rb
@@ -8,13 +8,24 @@ class CacheSumAttributeWordCountJob < ApplicationJob
     entity = entity_type.constantize.find_by(id: entity_id)
     return if entity.nil?
 
-    sum_attribute_word_count = Attribute.where(entity_type: entity_type, entity_id: entity_id).sum(:word_count_cache)
+    save_daily_word_count_changes(entity)
+  end
+
+  def save_daily_word_count_changes(entity)
+    # Grab the latest total word count for this entity
+    sum_attribute_word_count = Attribute.where(entity_type: entity.class.name, entity_id: entity.id).sum(:word_count_cache)
+
+    # Cache the total word count onto the model, too
+    entity.update(cached_word_count: sum_attribute_word_count)
+
+    # Create or re-use an existing WordCountUpdate for today
     update = entity.word_count_updates.find_or_initialize_by(
       for_date: DateTime.current,
     )
     update.word_count = sum_attribute_word_count
     update.user_id  ||= entity.user_id
 
+    # Save!
     update.save!
   end
 end

--- a/app/models/page_types/content_page.rb
+++ b/app/models/page_types/content_page.rb
@@ -4,7 +4,7 @@ class ContentPage < ApplicationRecord
   belongs_to :user
   belongs_to :universe
 
-  attr_accessor :favorite
+  attr_accessor :favorite, :cached_word_count
 
   include Authority::Abilities
   self.authorizer_name = 'ContentPageAuthorizer'
@@ -38,6 +38,6 @@ class ContentPage < ApplicationRecord
   end
 
   def self.polymorphic_content_fields
-    [:id, :name, :favorite, :page_type, :user_id, :created_at, :updated_at, :deleted_at, :archived_at, :privacy]
+    [:id, :name, :favorite, :page_type, :user_id, :cached_word_count, :created_at, :updated_at, :deleted_at, :archived_at, :privacy]
   end
 end

--- a/app/models/serializers/content_serializer.rb
+++ b/app/models/serializers/content_serializer.rb
@@ -10,6 +10,8 @@ class ContentSerializer
   attr_accessor :raw_model
   attr_accessor :class_name, :class_color, :class_icon
 
+  attr_accessor :cached_word_count
+
   attr_accessor :data
   # name: 'blah,
   # categories: [
@@ -43,6 +45,8 @@ class ContentSerializer
 
     self.page_tags        = content.page_tags.pluck(:tag) || []
     self.documents        = content.documents || []
+
+    self.cached_word_count = content.cached_word_count
 
     self.data = {
       name: content.try(:name),

--- a/app/views/content/show.html.erb
+++ b/app/views/content/show.html.erb
@@ -43,6 +43,16 @@
             content: @serialized_content
           }
       %>
+
+      <!--
+      Enable this after the caches have all been busted/recomputed :)
+      <% if @serialized_content.cached_word_count && @serialized_content.cached_word_count > 0 %>
+        <div class="grey-text center">
+          <%= number_with_delimiter @serialized_content.cached_word_count %>
+          <%= 'word'.pluralize(@serialized_content.cached_word_count) %>  
+        </div>
+      <% end %>
+      -->
     </div>
   </div>
 

--- a/db/migrate/20221202003053_add_cached_word_counts_to_worldbuilding_pages.rb
+++ b/db/migrate/20221202003053_add_cached_word_counts_to_worldbuilding_pages.rb
@@ -1,0 +1,9 @@
+class AddCachedWordCountsToWorldbuildingPages < ActiveRecord::Migration[6.1]
+  def change
+    Rails.application.config.content_types[:all].each do |content_type|
+      add_column            content_type.name.downcase.pluralize, :cached_word_count, :integer           # Add column without default lock
+      change_column_default content_type.name.downcase.pluralize, :cached_word_count, from: nil, to: 0   # Add default value
+      change_column_null    content_type.name.downcase.pluralize, :cached_word_count, true               # Ensure null is still allowed (for now)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_17_213907) do
+ActiveRecord::Schema.define(version: 2022_12_02_003053) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -277,6 +277,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["universe_id"], name: "index_buildings_on_universe_id"
     t.index ["user_id", "universe_id", "deleted_at"], name: "index_buildings_on_user_id_and_universe_id_and_deleted_at"
     t.index ["user_id"], name: "index_buildings_on_user_id"
@@ -431,6 +432,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["deleted_at", "id"], name: "index_characters_on_deleted_at_and_id"
     t.index ["deleted_at", "universe_id"], name: "index_characters_on_deleted_at_and_universe_id"
     t.index ["deleted_at", "user_id"], name: "index_characters_on_deleted_at_and_user_id"
@@ -459,6 +461,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["universe_id"], name: "index_conditions_on_universe_id"
     t.index ["user_id", "universe_id", "deleted_at"], name: "index_conditions_on_user_id_and_universe_id_and_deleted_at"
     t.index ["user_id"], name: "index_conditions_on_user_id"
@@ -626,6 +629,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["deleted_at", "id", "universe_id"], name: "index_continents_on_deleted_at_and_id_and_universe_id"
     t.index ["deleted_at", "id", "user_id"], name: "index_continents_on_deleted_at_and_id_and_user_id"
     t.index ["deleted_at", "id"], name: "index_continents_on_deleted_at_and_id"
@@ -670,6 +674,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["deleted_at", "id"], name: "index_countries_on_deleted_at_and_id"
     t.index ["deleted_at", "universe_id"], name: "index_countries_on_deleted_at_and_universe_id"
     t.index ["deleted_at", "user_id"], name: "index_countries_on_deleted_at_and_user_id"
@@ -828,6 +833,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["deleted_at", "id"], name: "index_creatures_on_deleted_at_and_id"
     t.index ["deleted_at", "universe_id"], name: "index_creatures_on_deleted_at_and_universe_id"
     t.index ["deleted_at", "user_id"], name: "index_creatures_on_deleted_at_and_user_id"
@@ -873,6 +879,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["deleted_at", "id"], name: "index_deities_on_deleted_at_and_id"
     t.index ["deleted_at", "universe_id"], name: "index_deities_on_deleted_at_and_universe_id"
     t.index ["deleted_at", "user_id"], name: "index_deities_on_deleted_at_and_user_id"
@@ -1338,6 +1345,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["deleted_at", "id"], name: "index_floras_on_deleted_at_and_id"
     t.index ["deleted_at", "universe_id"], name: "index_floras_on_deleted_at_and_universe_id"
     t.index ["deleted_at", "user_id"], name: "index_floras_on_deleted_at_and_user_id"
@@ -1373,6 +1381,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["universe_id"], name: "index_foods_on_universe_id"
     t.index ["user_id", "universe_id", "deleted_at"], name: "index_foods_on_user_id_and_universe_id_and_deleted_at"
     t.index ["user_id"], name: "index_foods_on_user_id"
@@ -1492,6 +1501,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["deleted_at", "id"], name: "index_governments_on_deleted_at_and_id"
     t.index ["deleted_at", "universe_id"], name: "index_governments_on_deleted_at_and_universe_id"
     t.index ["deleted_at", "user_id"], name: "index_governments_on_deleted_at_and_user_id"
@@ -1588,6 +1598,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["deleted_at", "id"], name: "index_groups_on_deleted_at_and_id"
     t.index ["deleted_at", "universe_id"], name: "index_groups_on_deleted_at_and_universe_id"
     t.index ["deleted_at", "user_id"], name: "index_groups_on_deleted_at_and_user_id"
@@ -1668,6 +1679,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["deleted_at", "id"], name: "index_items_on_deleted_at_and_id"
     t.index ["deleted_at", "universe_id"], name: "index_items_on_deleted_at_and_universe_id"
     t.index ["deleted_at", "user_id"], name: "index_items_on_deleted_at_and_user_id"
@@ -1690,6 +1702,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["universe_id"], name: "index_jobs_on_universe_id"
     t.index ["user_id", "universe_id", "deleted_at"], name: "index_jobs_on_user_id_and_universe_id_and_deleted_at"
     t.index ["user_id"], name: "index_jobs_on_user_id"
@@ -1765,6 +1778,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["deleted_at", "id"], name: "index_landmarks_on_deleted_at_and_id"
     t.index ["deleted_at", "universe_id"], name: "index_landmarks_on_deleted_at_and_universe_id"
     t.index ["deleted_at", "user_id"], name: "index_landmarks_on_deleted_at_and_user_id"
@@ -1797,6 +1811,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["deleted_at", "id"], name: "index_languages_on_deleted_at_and_id"
     t.index ["deleted_at", "universe_id"], name: "index_languages_on_deleted_at_and_universe_id"
     t.index ["deleted_at", "user_id"], name: "index_languages_on_deleted_at_and_user_id"
@@ -1911,6 +1926,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["deleted_at", "id"], name: "index_locations_on_deleted_at_and_id"
     t.index ["deleted_at", "universe_id"], name: "index_locations_on_deleted_at_and_universe_id"
     t.index ["deleted_at", "user_id"], name: "index_locations_on_deleted_at_and_user_id"
@@ -2235,6 +2251,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.string "page_type", default: "Lore"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "cached_word_count", default: 0
     t.index ["universe_id"], name: "index_lores_on_universe_id"
     t.index ["user_id"], name: "index_lores_on_user_id"
   end
@@ -2271,6 +2288,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["deleted_at", "id"], name: "index_magics_on_deleted_at_and_id"
     t.index ["deleted_at", "universe_id"], name: "index_magics_on_deleted_at_and_universe_id"
     t.index ["deleted_at", "user_id"], name: "index_magics_on_deleted_at_and_user_id"
@@ -2651,6 +2669,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["deleted_at", "id"], name: "index_planets_on_deleted_at_and_id"
     t.index ["deleted_at", "universe_id"], name: "index_planets_on_deleted_at_and_universe_id"
     t.index ["deleted_at", "user_id"], name: "index_planets_on_deleted_at_and_user_id"
@@ -2705,6 +2724,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["deleted_at", "id"], name: "index_races_on_deleted_at_and_id"
     t.index ["deleted_at", "universe_id"], name: "index_races_on_deleted_at_and_universe_id"
     t.index ["deleted_at", "user_id"], name: "index_races_on_deleted_at_and_user_id"
@@ -2779,6 +2799,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["deleted_at", "id"], name: "index_religions_on_deleted_at_and_id"
     t.index ["deleted_at", "universe_id"], name: "index_religions_on_deleted_at_and_universe_id"
     t.index ["deleted_at", "user_id"], name: "index_religions_on_deleted_at_and_user_id"
@@ -2845,6 +2866,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["deleted_at", "id"], name: "index_scenes_on_deleted_at_and_id"
     t.index ["deleted_at", "universe_id"], name: "index_scenes_on_deleted_at_and_universe_id"
     t.index ["deleted_at", "user_id"], name: "index_scenes_on_deleted_at_and_user_id"
@@ -2867,6 +2889,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["universe_id"], name: "index_schools_on_universe_id"
     t.index ["user_id", "universe_id", "deleted_at"], name: "index_schools_on_user_id_and_universe_id_and_deleted_at"
     t.index ["user_id"], name: "index_schools_on_user_id"
@@ -2916,6 +2939,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["universe_id"], name: "index_sports_on_universe_id"
     t.index ["user_id", "universe_id", "deleted_at"], name: "index_sports_on_user_id_and_universe_id_and_deleted_at"
     t.index ["user_id"], name: "index_sports_on_user_id"
@@ -2980,6 +3004,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["deleted_at", "id"], name: "index_technologies_on_deleted_at_and_id"
     t.index ["deleted_at", "universe_id"], name: "index_technologies_on_deleted_at_and_universe_id"
     t.index ["deleted_at", "user_id"], name: "index_technologies_on_deleted_at_and_user_id"
@@ -3474,6 +3499,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["deleted_at", "id"], name: "index_towns_on_deleted_at_and_id"
     t.index ["deleted_at", "universe_id"], name: "index_towns_on_deleted_at_and_universe_id"
     t.index ["deleted_at", "user_id"], name: "index_towns_on_deleted_at_and_user_id"
@@ -3495,6 +3521,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["universe_id"], name: "index_traditions_on_universe_id"
     t.index ["user_id", "universe_id", "deleted_at"], name: "index_traditions_on_user_id_and_universe_id_and_deleted_at"
     t.index ["user_id"], name: "index_traditions_on_user_id"
@@ -3519,6 +3546,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["deleted_at", "id"], name: "index_universes_on_deleted_at_and_id"
     t.index ["deleted_at", "user_id"], name: "index_universes_on_deleted_at_and_user_id"
     t.index ["deleted_at"], name: "index_universes_on_deleted_at"
@@ -3618,6 +3646,7 @@ ActiveRecord::Schema.define(version: 2022_08_17_213907) do
     t.datetime "archived_at"
     t.boolean "favorite", default: false
     t.boolean "columns_migrated_from_old_style", default: true
+    t.integer "cached_word_count", default: 0
     t.index ["universe_id"], name: "index_vehicles_on_universe_id"
     t.index ["user_id", "universe_id", "deleted_at"], name: "index_vehicles_on_user_id_and_universe_id_and_deleted_at"
     t.index ["user_id"], name: "index_vehicles_on_user_id"

--- a/lib/tasks/cache.rake
+++ b/lib/tasks/cache.rake
@@ -58,7 +58,7 @@ namespace :cache do
 
       content_type.order('updated_at DESC').find_each do |entity|
         sum_attribute_word_count = Attribute.where(entity_type: content_type.name, entity_id: entity.id).sum(:word_count_cache)
-        entity.update(cached_word_count: sum_attribute_word_count)
+        entity.update_column(:cached_word_count, sum_attribute_word_count)
       end
     end
   end


### PR DESCRIPTION
Prepare to show word counts on every page by busting the existing caches and recomputing everything, while also adding a trigger to update the cache whenever an attribute value changes