### PR TITLE
Add production domain to allowed hosts configuration

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,7 +1,9 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # Allow PR environments on Railway (auto-deployed dynamic domains)
+  # Allow production and PR environment domains
+  config.hosts << "notebook.ai"
+  config.hosts << "www.notebook.ai"
   config.hosts << /.*\.up\.railway\.app/
   config.hosts << ENV["RAILWAY_PUBLIC_DOMAIN"] if ENV["RAILWAY_PUBLIC_DOMAIN"].present?
 


### PR DESCRIPTION
Fixes #

Changes proposed:

- Add `notebook.ai` and `www.notebook.ai` to the allowed hosts list in production environment
- Update comment to clarify that configuration allows both production and PR environment domains
- Maintain existing Railway dynamic domain support for PR environments

@indentlabs/contributors

https://claude.ai/code/session_01SFHriJmpYp53hdbLigxLiG