### PR TITLE
Finish Table of Contents feature for public universe browsing

### DIFF
--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -53,28 +53,38 @@ class MainController < ApplicationController
   end
 
   def table_of_contents
-    @toc_scope = @universe_scope || current_user
-    @toc_user  = @universe_scope.try(:user) || current_user
+    @universe = Universe.find(params[:id])
 
-    # Get content list - handle differently depending on whether we're scoped to a universe or a user
-    content_list = if @toc_scope.is_a?(Universe)
-      # For a Universe, we need to get content from the user that's in this universe
-      user_content = @toc_user.content_list(page_scoping: { user_id: @toc_user.id })
-      universe_id = @toc_scope.id
-      user_content.select { |page| page['universe_id']&.to_i == universe_id || page['page_type'] == 'Universe' && page['id'] == universe_id }
-    else
-      # For a User, we can directly use their content_list method
-      @toc_scope.content_list
+    unless @universe.public_content?
+      raise ActiveRecord::RecordNotFound
     end
 
-    # Sort the content list by name
-    content_list = content_list.sort_by { |page| page['name'] }
+    @toc_user  = @universe.user
+    @page_title = "#{@universe.name} — Table of Contents"
 
-    @starred_pages = content_list.select { |page| page['favorite'] == 1 }
-    @other_pages   = content_list.select { |page| page['favorite'] == 0 }
-
+    # Gather all public, non-deleted content in this universe
+    all_pages = []
     @page_type_counts = Hash.new(0)
-    content_list.each { |page| @page_type_counts[page['page_type']] += 1 }
+
+    Rails.application.config.content_types[:all_non_universe].each do |content_type|
+      relation = content_type.name.downcase.pluralize.to_sym
+      pages = @universe.send(relation)
+                       .is_public
+                       .where(deleted_at: nil, archived_at: nil)
+      pages.each do |page|
+        all_pages << page
+        @page_type_counts[content_type.name] += 1
+      end
+    end
+
+    all_pages.sort_by!(&:name)
+    @starred_pages = all_pages.select { |p| p.try(:favorite) }
+    @other_pages   = all_pages.reject { |p| p.try(:favorite) }
+
+    # Statistics
+    @total_pages = all_pages.size
+    @total_words = all_pages.sum { |p| p.try(:cached_word_count).to_i }
+    @content_type_count = @page_type_counts.keys.size
   end
 
   def infostack

--- a/app/javascript/controllers/toc_filter_controller.js
+++ b/app/javascript/controllers/toc_filter_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static targets = ["page", "allFilter"]
+
+  filter(event) {
+    const selectedType = event.currentTarget.dataset.pageType
+
+    this.pageTargets.forEach(el => {
+      el.style.display = el.dataset.pageType === selectedType ? "" : "none"
+    })
+  }
+
+  showAll() {
+    this.pageTargets.forEach(el => {
+      el.style.display = ""
+    })
+  }
+}

--- a/app/views/main/table_of_contents.html.erb
+++ b/app/views/main/table_of_contents.html.erb
@@ -4,28 +4,19 @@
     <main class="mt-16 mx-auto max-w-7xl px-4 sm:mt-24">
       <div class="text-center">
         <h1 class="text-4xl tracking-tight font-extrabold text-gray-900 sm:text-5xl md:text-6xl">
-          <span class="<%= Universe.text_color %>"><%= @toc_scope.name %></span>
+          <span class="<%= Universe.text_color %>"><%= @universe.name %></span>
         </h1>
         <h2 class="text-gray-400 tracking-wider">
           a universe by
           <%= link_to @toc_user.display_name, @toc_user, class: User.text_color %>
         </h2>
-        <p class="mt-3 max-w-md mx-auto text-base text-gray-500 sm:text-lg md:mt-5 md:text-xl md:max-w-3xl">
-          scope description
-        </p>
+        <% if @universe.description.present? %>
+          <p class="mt-3 max-w-md mx-auto text-base text-gray-500 sm:text-lg md:mt-5 md:text-xl md:max-w-3xl">
+            <%= @universe.description %>
+          </p>
+        <% end %>
       </div>
     </main>
-    
-    <div class="mt-8">
-      <div class="max-w-7xl mx-auto px-4 sm:px-6">
-        <nav class="relative flex items-center justify-between sm:h-10 md:justify-center" aria-label="Global">
-          <div class="hidden md:flex md:space-x-10">
-            <a href="#" class="font-medium text-gray-500 hover:text-gray-900 hover:bg-white rounded-lg hover:border-gray-200 border-transparent border px-4">Worldbuilding</a>
-            <a href="#" class="font-medium text-gray-500 hover:text-gray-900 hover:bg-white rounded-lg hover:border-gray-200 border-transparent border px-4">Documents</a>
-          </div>
-        </nav>
-      </div>
-    </div>
 
   </div>
 </div>
@@ -43,16 +34,11 @@
         <div class="mt-12 lg:mt-0 lg:col-span-2">
           <dl>
             <% @starred_pages.each do |page| %>
-              <%= link_to polymorphic_path(page['page_type'].downcase, id: page['id']), class: 'block px-4 py-3 hover:bg-white rounded-lg hover:border-gray-200 border-transparent border' do %>
-                <dt class="text-lg leading-6 font-medium <%= content_class_from_name(page['page_type']).text_color %>">
-                  <i class="material-icons float-left mr-2"><%= content_class_from_name(page['page_type']).icon %></i>
-                  <%= page['name'] %>
+              <%= link_to polymorphic_path(page.page_type.downcase, id: page.id), class: 'block px-4 py-3 hover:bg-white rounded-lg hover:border-gray-200 border-transparent border' do %>
+                <dt class="text-lg leading-6 font-medium <%= content_class_from_name(page.page_type).text_color %>">
+                  <i class="material-icons float-left mr-2"><%= content_class_from_name(page.page_type).icon %></i>
+                  <%= page.name %>
                 </dt>
-                <!--
-                <dd class="mt-2 text-base text-gray-500">
-                  Description
-                </dd>
-                -->
               <% end %>
             <% end %>
           </dl>
@@ -62,30 +48,43 @@
   </div>
 <% end %>
 
-<div class="">
+<div data-controller="toc-filter">
   <div class="max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:py-20 lg:px-8">
     <div class="lg:grid lg:grid-cols-3 lg:gap-8">
       <div class="lg:pr-32">
         <h2 class="text-3xl font-extrabold text-gray-900">All pages</h2>
         <p class="mt-8 text-lg text-gray-500">
-          Filter by page type...
+          Filter by page type
         </p>
 
         <ul role="list" class="border border-gray-200 rounded-md divide-y divide-gray-200 mt-2 bg-white">
+          <li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm rounded-full hover:bg-notebook-blue hover:text-white group cursor-pointer"
+              data-action="click->toc-filter#showAll"
+              data-toc-filter-target="allFilter">
+            <div class="w-0 flex-1 flex items-center">
+              <i class="material-icons float-left bg-white p-1 h-8 w-8 rounded-full text-gray-400">select_all</i>
+              <span class="ml-2 flex-1 w-0 truncate font-medium">All types</span>
+            </div>
+            <div class="ml-4 flex-shrink-0">
+              <span class="bg-gray-100 rounded px-1 text-xs group-hover:bg-notebook-blue">
+                <%= @total_pages %>
+              </span>
+            </div>
+          </li>
           <% @page_type_counts.each do |page_type, count| %>
-            <%= link_to '#' do %>
-              <li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm rounded-full hover:bg-notebook-blue hover:text-white group">
-                <div class="w-0 flex-1 flex items-center">
-                  <i class="material-icons float-left <%= content_class_from_name(page_type).text_color %> bg-white p-1 h-8 w-8 rounded-full"><%= content_class_from_name(page_type).icon %></i>
-                  <span class="ml-2 flex-1 w-0 truncate"><%= page_type.pluralize %></span>
-                </div>
-                <div class="ml-4 flex-shrink-0">
-                  <span class="bg-gray-100 rounded px-1 text-xs group-hover:bg-notebook-blue">
-                    <%= count %>
-                  </span>
-                </div>
-              </li>
-            <% end %>
+            <li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm rounded-full hover:bg-notebook-blue hover:text-white group cursor-pointer"
+                data-action="click->toc-filter#filter"
+                data-page-type="<%= page_type %>">
+              <div class="w-0 flex-1 flex items-center">
+                <i class="material-icons float-left <%= content_class_from_name(page_type).text_color %> bg-white p-1 h-8 w-8 rounded-full"><%= content_class_from_name(page_type).icon %></i>
+                <span class="ml-2 flex-1 w-0 truncate"><%= page_type.pluralize %></span>
+              </div>
+              <div class="ml-4 flex-shrink-0">
+                <span class="bg-gray-100 rounded px-1 text-xs group-hover:bg-notebook-blue">
+                  <%= count %>
+                </span>
+              </div>
+            </li>
           <% end %>
         </ul>
 
@@ -93,16 +92,13 @@
       <div class="mt-12 lg:mt-0 lg:col-span-2">
         <dl>
           <% @other_pages.each do |page| %>
-            <%= link_to polymorphic_path(page['page_type'].downcase, id: page['id']), class: 'block px-4 py-3 hover:bg-white rounded-lg hover:border-gray-200 border-transparent border' do %>
-              <dt class="text-lg leading-6 font-medium <%= content_class_from_name(page['page_type']).text_color %>">
-                <i class="material-icons float-left mr-2"><%= content_class_from_name(page['page_type']).icon %></i>
-                <%= page['name'] %>
+            <%= link_to polymorphic_path(page.page_type.downcase, id: page.id),
+                class: 'block px-4 py-3 hover:bg-white rounded-lg hover:border-gray-200 border-transparent border',
+                data: { toc_filter_target: 'page', page_type: page.page_type } do %>
+              <dt class="text-lg leading-6 font-medium <%= content_class_from_name(page.page_type).text_color %>">
+                <i class="material-icons float-left mr-2"><%= content_class_from_name(page.page_type).icon %></i>
+                <%= page.name %>
               </dt>
-              <!--
-              <dd class="mt-2 text-base text-gray-500">
-                Description
-              </dd>
-              -->
             <% end %>
           <% end %>
         </dl>
@@ -111,30 +107,7 @@
   </div>
 </div>
 
-<div class="bg-white">
-  <div class="max-w-7xl mx-auto py-24 px-4 sm:px-6 lg:py-32 lg:px-8 lg:flex lg:items-center">
-    <div class="lg:w-0 lg:flex-1">
-      <h2 class="text-3xl font-extrabold text-gray-900 sm:text-4xl">Follow this universe</h2>
-      <p class="mt-3 max-w-3xl text-lg text-gray-500">
-        Stay connected and be notified as this world grows!
-      </p>
-    </div>
-    <div class="mt-8 lg:mt-0 lg:ml-8">
-      <form class="sm:flex">
-        <label for="email-address" class="sr-only">Email address</label>
-        <input id="email-address" name="email-address" type="email" autocomplete="email" required class="w-full px-5 py-3 border border-gray-300 shadow-sm placeholder-gray-400 focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:max-w-xs rounded-md" placeholder="Enter your email">
-        <div class="mt-3 rounded-md shadow sm:mt-0 sm:ml-3 sm:flex-shrink-0">
-          <button type="submit" class="w-full flex items-center justify-center py-3 px-5 border border-transparent text-base font-medium rounded-md text-white bg-notebook-blue hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">Notify me</button>
-        </div>
-      </form>
-      <p class="mt-3 text-sm text-gray-500">
-        Your email address won't be shared with <%= @toc_user.display_name %>.
-      </p>
-    </div>
-  </div>
-</div>
-
-<section class="container mx-auto">
+<section class="container mx-auto pb-16">
   <div>
     <dl class="mt-5 grid grid-cols-1 gap-5 sm:grid-cols-3 text-center">
       <div class="px-4 py-5 bg-white shadow rounded-lg overflow-hidden sm:p-6">
@@ -142,7 +115,7 @@
         <dd
           data-controller="animated-number"
           data-animated-number-start-value="0"
-          data-animated-number-end-value="5192"
+          data-animated-number-end-value="<%= @total_pages %>"
           data-animated-number-duration-value="700"
           class="mt-1 text-3xl font-semibold text-gray-900"
         ></dd>
@@ -153,15 +126,21 @@
         <dd
           data-controller="animated-number"
           data-animated-number-start-value="0"
-          data-animated-number-end-value="85192"
+          data-animated-number-end-value="<%= @total_words %>"
           data-animated-number-duration-value="800"
           class="mt-1 text-3xl font-semibold text-gray-900"
         ></dd>
       </div>
 
       <div class="px-4 py-5 bg-white shadow rounded-lg overflow-hidden sm:p-6">
-        <dt class="text-sm font-medium text-gray-500 truncate">Something</dt>
-        <dd class="mt-1 text-3xl font-semibold text-gray-900">24.57%</dd>
+        <dt class="text-sm font-medium text-gray-500 truncate">Page Types</dt>
+        <dd
+          data-controller="animated-number"
+          data-animated-number-start-value="0"
+          data-animated-number-end-value="<%= @content_type_count %>"
+          data-animated-number-duration-value="500"
+          class="mt-1 text-3xl font-semibold text-gray-900"
+        ></dd>
       </div>
     </dl>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -286,6 +286,8 @@ Rails.application.routes.draw do
   post 'universes/:universe_id/contributors', to: 'contributors#create', as: :universe_contributors
   get '/unsubscribe/emails/:code', to: 'emails#one_click_unsubscribe'
 
+  get '/universes/:id/contents', to: 'main#table_of_contents', as: :universe_contents
+
   get '/paper', to: redirect('https://www.notebook-paper.com')
 
   # Help Center - Public routes


### PR DESCRIPTION
Wire up the previously unfinished Table of Contents as a public-facing landing page for universes at /universes/:id/contents. Rewrites the controller to load universes by ID with privacy enforcement (only public universes are visible), replaces the buggy content_list approach (which couldn't filter by universe_id) with proper has_many associations and is_public scoping. Fixes the view to use real data instead of hardcoded placeholders, removes the non-functional email subscription form and nav tabs, adds a Stimulus-based page type filter, and wires up animated stats cards with actual page count, word count, and content type count.

https://claude.ai/code/session_01DUjQpL3cB9hqZaJ9j4wJwx

Fixes #

Changes proposed:

 - 
 
 -
 
 -

@indentlabs/contributors
