### PR TITLE
Treat blank word counts as zero (fixes dashboard NoMethodError)

### DIFF
--- a/app/models/word_count_update.rb
+++ b/app/models/word_count_update.rb
@@ -122,7 +122,7 @@ class WordCountUpdate < ApplicationRecord
           .max_by(&:for_date)
 
         prev_count = prev_record&.word_count || 0
-        delta = today_record.word_count - prev_count
+        delta = (today_record.word_count || 0) - prev_count
         if today_record.entity_type == 'ManualAdjustment' || delta > 0
           total_delta += delta
         end

--- a/app/models/word_count_update.rb
+++ b/app/models/word_count_update.rb
@@ -3,6 +3,11 @@ class WordCountUpdate < ApplicationRecord
   belongs_to :entity, polymorphic: true, optional: true
   validates :entity, presence: true, unless: :is_manual_adjustment?
 
+  # A blank word count means zero words written, never "unknown".
+  # Normalize here so a blank manual-adjustment form submission (which
+  # typecasts to nil for an integer column) is stored as 0.
+  before_validation { self.word_count ||= 0 }
+
   after_commit :check_daily_word_goal, on: [:create, :update]
 
   def is_manual_adjustment?
@@ -31,7 +36,7 @@ class WordCountUpdate < ApplicationRecord
     # Keep the record with the highest word_count per entity
     today_records = today_records
       .group_by { |r| [r.entity_type, r.entity_id] }
-      .transform_values { |records| records.max_by(&:word_count) }
+      .transform_values { |records| records.max_by { |r| r.word_count || 0 } }
       .values
 
     # Get the previous record for each entity in a single query using a subquery
@@ -74,7 +79,7 @@ class WordCountUpdate < ApplicationRecord
     total_delta = 0
     today_records.each do |record|
       prev_count = prev_word_counts[[record.entity_type, record.entity_id]] || 0
-      delta = record.word_count - prev_count
+      delta = (record.word_count || 0) - prev_count
       if record.entity_type == 'ManualAdjustment' || delta > 0
         total_delta += delta
       end

--- a/test/models/word_count_update_test.rb
+++ b/test/models/word_count_update_test.rb
@@ -200,4 +200,32 @@ class WordCountUpdateTest < ActiveSupport::TestCase
     assert_not result.include?(Date.current - 1.day), "Day with only deletions should not be active"
     assert result.include?(Date.current), "Day with 100 word addition should be active"
   end
+
+  test "blank word count is stored as zero" do
+    update = WordCountUpdate.create!(
+      user: @user,
+      entity: @document,
+      word_count: nil,
+      for_date: Date.current
+    )
+
+    assert_equal 0, update.reload.word_count
+  end
+
+  test "batch_words_written_on_dates tolerates pre-existing nil word counts" do
+    # Simulate a legacy/dirty row that already has a nil word_count in the DB,
+    # bypassing the before_validation normalization with update_column.
+    record = WordCountUpdate.create!(
+      user: @user,
+      entity: @document,
+      word_count: 0,
+      for_date: Date.current
+    )
+    record.update_column(:word_count, nil)
+
+    assert_nothing_raised do
+      result = WordCountUpdate.batch_words_written_on_dates(@user, [Date.current])
+      assert_equal 0, result[Date.current]
+    end
+  end
 end


### PR DESCRIPTION
## Problem

`MainController#dashboard` was crashing with `undefined method '-' for nil:NilClass` at `app/models/word_count_update.rb:125`:

```ruby
delta = today_record.word_count - prev_count   # nil - 0 💥
```

**Root cause:** the `word_count` column on `word_count_updates` is nullable with no default. The manual-adjustment form (`WordCountUpdatesController#create`) permits `:word_count`, has no presence validation, and a blank field typecasts to `nil` for an integer column — so a `word_count: nil` row gets persisted and later crashes the dashboard reads.

## Fix

Per product intent, **a blank word count means 0 words written**, not "unknown".

- **Write side:** `before_validation { self.word_count ||= 0 }` normalizes blank/nil to `0`, so no new nil rows can be created.
- **Read side:** guard the three subtraction/comparison spots (`:125`, `:77`, `:34`) so rows with a pre-existing `nil` already in the DB are tolerated until they age out.
- **Tests:** blank → stored as `0`, and `batch_words_written_on_dates` no longer raises on a legacy nil row.

## Notes

- I did **not** add a DB migration. Behavior is correct without one (nil impossible on write, tolerated on read). The cleaner long-term version would backfill existing nil rows and add `null: false, default: 0`, after which the read-side `|| 0` guards could be removed. Happy to add that if wanted.
- The test suite was **not executed** in the session container (gems not installed; `bundle install` requires a private git gem). Files were syntax-checked with `ruby -c` only — please confirm via CI.

https://claude.ai/code/session_01FG7eHCyovD5MmP8yaEzNsy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FG7eHCyovD5MmP8yaEzNsy)_