### PR TITLE
Refactor user tag path generation to handle legacy users

### DIFF
--- a/app/helpers/page_tags_helper.rb
+++ b/app/helpers/page_tags_helper.rb
@@ -1,2 +1,13 @@
 module PageTagsHelper
+  # Builds a path to a user's public tag page, falling back to the ID-based
+  # route for legacy users who have no username set. Using user_tag_path
+  # directly with a nil username raises ActionController::UrlGenerationError,
+  # so all "link to this user's tag page" call sites should go through here.
+  def user_tag_path_for(user, tag_slug)
+    if user&.username.present?
+      user_tag_path(username: user.username, tag_slug: tag_slug)
+    else
+      user_id_tag_path(id: user.id, tag_slug: tag_slug)
+    end
+  end
 end

--- a/app/views/content/list/_cards.html.erb
+++ b/app/views/content/list/_cards.html.erb
@@ -45,7 +45,7 @@
                       <span class="new badge <%= params[:tag] == tag.slug ? content_type.color : 'grey' %> left" data-badge-caption="<%= tag.tag %>"></span>
                     <% end %>
                   <% else %>
-                    <%= link_to user_tag_path(username: content.user.username, tag_slug: tag.slug) do %>
+                    <%= link_to (content.user.username.present? ? user_tag_path(username: content.user.username, tag_slug: tag.slug) : user_id_tag_path(id: content.user.id, tag_slug: tag.slug)) do %>
                       <span class="new badge <%= params[:tag] == tag.slug ? content_type.color : 'grey' %> left" data-badge-caption="<%= tag.tag %>"></span>
                     <% end %>
                   <% end %>

--- a/app/views/content/list/_cards.html.erb
+++ b/app/views/content/list/_cards.html.erb
@@ -45,7 +45,7 @@
                       <span class="new badge <%= params[:tag] == tag.slug ? content_type.color : 'grey' %> left" data-badge-caption="<%= tag.tag %>"></span>
                     <% end %>
                   <% else %>
-                    <%= link_to (content.user.username.present? ? user_tag_path(username: content.user.username, tag_slug: tag.slug) : user_id_tag_path(id: content.user.id, tag_slug: tag.slug)) do %>
+                    <%= link_to user_tag_path_for(content.user, tag.slug) do %>
                       <span class="new badge <%= params[:tag] == tag.slug ? content_type.color : 'grey' %> left" data-badge-caption="<%= tag.tag %>"></span>
                     <% end %>
                   <% end %>
@@ -94,7 +94,7 @@
                     <span class="new badge <%= params[:tag] == tag.slug ? content_type.color : 'grey' %> left" data-badge-caption="<%= tag.tag %>"></span>
                   <% end %>
                 <% else %>
-                  <%= link_to user_tag_path(username: content.user.username, tag_slug: tag.slug) do %>
+                  <%= link_to user_tag_path_for(content.user, tag.slug) do %>
                     <span class="new badge <%= params[:tag] == tag.slug ? content_type.color : 'grey' %> left" data-badge-caption="<%= tag.tag %>"></span>
                   <% end %>
                 <% end %>

--- a/app/views/content/list/_dense_cards.html.erb
+++ b/app/views/content/list/_dense_cards.html.erb
@@ -31,7 +31,7 @@
                         <span class="new badge <%= params[:tag] == tag.slug ? 'orange' : 'grey' %> left" data-badge-caption="<%= tag.tag %>"></span>
                       <% end %>
                     <% else %>
-                      <%= link_to user_tag_path(username: content.user.username, tag_slug: tag.slug) do %>
+                      <%= link_to (content.user.username.present? ? user_tag_path(username: content.user.username, tag_slug: tag.slug) : user_id_tag_path(id: content.user.id, tag_slug: tag.slug)) do %>
                         <span class="new badge <%= params[:tag] == tag.slug ? 'orange' : 'grey' %> left" data-badge-caption="<%= tag.tag %>"></span>
                       <% end %>
                     <% end %>

--- a/app/views/content/list/_dense_cards.html.erb
+++ b/app/views/content/list/_dense_cards.html.erb
@@ -31,7 +31,7 @@
                         <span class="new badge <%= params[:tag] == tag.slug ? 'orange' : 'grey' %> left" data-badge-caption="<%= tag.tag %>"></span>
                       <% end %>
                     <% else %>
-                      <%= link_to (content.user.username.present? ? user_tag_path(username: content.user.username, tag_slug: tag.slug) : user_id_tag_path(id: content.user.id, tag_slug: tag.slug)) do %>
+                      <%= link_to user_tag_path_for(content.user, tag.slug) do %>
                         <span class="new badge <%= params[:tag] == tag.slug ? 'orange' : 'grey' %> left" data-badge-caption="<%= tag.tag %>"></span>
                       <% end %>
                     <% end %>

--- a/app/views/content/list/_document_table.html.erb
+++ b/app/views/content/list/_document_table.html.erb
@@ -66,7 +66,7 @@
                             <span class="new badge <%= params[:tag] == tag.slug ? 'orange' : Document.color %> left" data-badge-caption="<%= tag.tag %>"></span>
                           <% end %>
                         <% else %>
-                          <%= link_to (document.user.username.present? ? user_tag_path(username: document.user.username, tag_slug: tag.slug) : user_id_tag_path(id: document.user.id, tag_slug: tag.slug)) do %>
+                          <%= link_to user_tag_path_for(document.user, tag.slug) do %>
                             <span class="new badge <%= params[:tag] == tag.slug ? 'orange' : Document.color %> left" data-badge-caption="<%= tag.tag %>"></span>
                           <% end %>
                         <% end %>

--- a/app/views/content/list/_document_table.html.erb
+++ b/app/views/content/list/_document_table.html.erb
@@ -66,7 +66,7 @@
                             <span class="new badge <%= params[:tag] == tag.slug ? 'orange' : Document.color %> left" data-badge-caption="<%= tag.tag %>"></span>
                           <% end %>
                         <% else %>
-                          <%= link_to user_tag_path(username: document.user.username, tag_slug: tag.slug) do %>
+                          <%= link_to (document.user.username.present? ? user_tag_path(username: document.user.username, tag_slug: tag.slug) : user_id_tag_path(id: document.user.id, tag_slug: tag.slug)) do %>
                             <span class="new badge <%= params[:tag] == tag.slug ? 'orange' : Document.color %> left" data-badge-caption="<%= tag.tag %>"></span>
                           <% end %>
                         <% end %>

--- a/app/views/content/list/_list.html.erb
+++ b/app/views/content/list/_list.html.erb
@@ -61,7 +61,7 @@
                 <span class="new badge <%= params[:tag] == tag.slug ? content.class.color : 'grey' %> left" data-badge-caption="<%= tag.tag %>"></span>
               <% end %>
             <% else %>
-              <%= link_to user_tag_path(username: content.user.username, tag_slug: tag.slug) do %>
+              <%= link_to (content.user.username.present? ? user_tag_path(username: content.user.username, tag_slug: tag.slug) : user_id_tag_path(id: content.user.id, tag_slug: tag.slug)) do %>
                 <span class="new badge <%= params[:tag] == tag.slug ? content.class.color : 'grey' %> left" data-badge-caption="<%= tag.tag %>"></span>
               <% end %>
             <% end %>

--- a/app/views/content/list/_list.html.erb
+++ b/app/views/content/list/_list.html.erb
@@ -61,7 +61,7 @@
                 <span class="new badge <%= params[:tag] == tag.slug ? content.class.color : 'grey' %> left" data-badge-caption="<%= tag.tag %>"></span>
               <% end %>
             <% else %>
-              <%= link_to (content.user.username.present? ? user_tag_path(username: content.user.username, tag_slug: tag.slug) : user_id_tag_path(id: content.user.id, tag_slug: tag.slug)) do %>
+              <%= link_to user_tag_path_for(content.user, tag.slug) do %>
                 <span class="new badge <%= params[:tag] == tag.slug ? content.class.color : 'grey' %> left" data-badge-caption="<%= tag.tag %>"></span>
               <% end %>
             <% end %>

--- a/app/views/users/content_list.html.erb
+++ b/app/views/users/content_list.html.erb
@@ -219,7 +219,7 @@
                 <% if content.respond_to?(:page_tags) && content.page_tags.any? %>
                   <div class="flex flex-wrap gap-1 mb-3">
                     <% content.page_tags.limit(3).each do |tag| %>
-                      <%= link_to (content.user.username.present? ? user_tag_path(username: content.user.username, tag_slug: tag.slug) : user_id_tag_path(id: content.user.id, tag_slug: tag.slug)), class: "inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors duration-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600" do %>
+                      <%= link_to user_tag_path_for(content.user, tag.slug), class: "inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors duration-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600" do %>
                         <%= tag.tag %>
                       <% end %>
                     <% end %>
@@ -292,7 +292,7 @@
                     <% if content.respond_to?(:page_tags) && content.page_tags.any? %>
                       <div class="flex flex-wrap gap-1 mb-2">
                         <% content.page_tags.limit(5).each do |tag| %>
-                          <%= link_to (content.user.username.present? ? user_tag_path(username: content.user.username, tag_slug: tag.slug) : user_id_tag_path(id: content.user.id, tag_slug: tag.slug)), class: "inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors duration-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600" do %>
+                          <%= link_to user_tag_path_for(content.user, tag.slug), class: "inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors duration-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600" do %>
                             <%= tag.tag %>
                           <% end %>
                         <% end %>

--- a/app/views/users/profile/_tags.html.erb
+++ b/app/views/users/profile/_tags.html.erb
@@ -7,7 +7,7 @@
     </div>
     <div class="collection-item" style="padding: 14px">
       <% @popular_tags.each do |tag| %>
-        <%= link_to @user.username.present? ? user_tag_path(username: @user.username, tag_slug: tag.slug) : user_id_tag_path(id: @user.id, tag_slug: tag.slug) do %>
+        <%= link_to user_tag_path_for(@user, tag.slug) do %>
           <span class="new badge blue lighten-1 left" data-badge-caption="<%= tag.tag %>"></span>
         <% end %>
       <% end %>

--- a/app/views/users/tabs/_overview.html.erb
+++ b/app/views/users/tabs/_overview.html.erb
@@ -245,7 +245,7 @@
           <div class="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-gray-200 dark:border-slate-700 p-6">
             <div class="flex flex-wrap gap-2">
               <% @popular_tags.first(10).each do |tag| %>
-                <% tag_path = @user.username.present? ? user_tag_path(username: @user.username, tag_slug: tag.slug) : user_id_tag_path(id: @user.id, tag_slug: tag.slug) %>
+                <% tag_path = user_tag_path_for(@user, tag.slug) %>
                 <%= link_to tag_path, 
                            class: "inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 hover:bg-blue-200 dark:hover:bg-blue-800 transition-colors duration-200" do %>
                   <i class="material-icons text-xs mr-1">tag</i>

--- a/app/views/users/tabs/_tags.html.erb
+++ b/app/views/users/tabs/_tags.html.erb
@@ -54,7 +54,7 @@
       <div class="flex flex-wrap gap-3 justify-center">
         <% @popular_tags.each do |tag| %>
           <div class="tag-item" data-name="<%= tag.tag.downcase %>" data-usage="<%= tag.usage_count %>">
-            <% tag_path = @user.username.present? ? user_tag_path(username: @user.username, tag_slug: tag.slug) : user_id_tag_path(id: @user.id, tag_slug: tag.slug) %>
+            <% tag_path = user_tag_path_for(@user, tag.slug) %>
             <%= link_to tag_path, {
                        class: "inline-flex items-center px-4 py-2 rounded-full font-medium transition-all duration-200 hover:scale-105 hover:shadow-md tag-link",
                        style: "font-size: #{[12 + (tag.usage_count * 2), 24].min}px;",
@@ -85,8 +85,8 @@
       <div class="divide-y divide-gray-200">
         <% @popular_tags.each do |tag| %>
           <div class="tag-list-item" data-name="<%= tag.tag.downcase %>" data-usage="<%= tag.usage_count %>">
-            <% tag_path = @user.username.present? ? user_tag_path(username: @user.username, tag_slug: tag.slug) : user_id_tag_path(id: @user.id, tag_slug: tag.slug) %>
-            <%= link_to tag_path, 
+            <% tag_path = user_tag_path_for(@user, tag.slug) %>
+            <%= link_to tag_path,
                        { class: "block px-6 py-4 hover:bg-gray-50 transition-colors duration-200" } do %>
               
               <div class="flex items-center justify-between">

--- a/app/views/users/tag.html.erb
+++ b/app/views/users/tag.html.erb
@@ -225,7 +225,7 @@
                                 <%= tag.tag %>
                               </span>
                             <% else %>
-                              <%= link_to (content.user.username.present? ? user_tag_path(username: content.user.username, tag_slug: tag.slug) : user_id_tag_path(id: content.user.id, tag_slug: tag.slug)), class: "inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors duration-200" do %>
+                              <%= link_to user_tag_path_for(content.user, tag.slug), class: "inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors duration-200" do %>
                                 <%= tag.tag %>
                               <% end %>
                             <% end %>


### PR DESCRIPTION
Fixes #

Changes proposed:

- Added `user_tag_path_for` helper method in `PageTagsHelper` to centralize logic for generating user tag paths with fallback support for legacy users without usernames
- Replaced 10 instances of inline conditional path generation across multiple views with calls to the new helper method
- The helper safely handles nil usernames by falling back to ID-based routes, preventing `ActionController::UrlGenerationError`

This refactoring eliminates code duplication and improves maintainability by consolidating the username presence check logic into a single, well-documented helper method. All tag path generation now goes through this helper, ensuring consistent behavior across the application.

@indentlabs/contributors

https://claude.ai/code/session_016kBpn4biiGPBMaPFPMBk6k