### PR TITLE
Fix timeline event reordering race conditions

### DIFF
--- a/app/assets/javascripts/timeline-editor.js
+++ b/app/assets/javascripts/timeline-editor.js
@@ -32,6 +32,20 @@ function calculateScrollSpeed(distanceFromEdge) {
   return minScrollSpeed + (maxScrollSpeed - minScrollSpeed) * normalized;
 }
 
+// Serialize timeline reorder requests so acts_as_list never processes two
+// concurrent position changes for the same timeline. Firing move/sort requests
+// in parallel let their position shuffles interleave on the server, which could
+// leave events with duplicate or garbled positions that only surfaced as a
+// scattered order after a page refresh.
+let timelineReorderChain = Promise.resolve();
+function enqueueTimelineReorder(taskFn) {
+  const result = timelineReorderChain.then(() => taskFn());
+  // Keep the chain alive even if a task rejects, so one failed reorder doesn't
+  // permanently stall every subsequent one.
+  timelineReorderChain = result.catch(() => {});
+  return result;
+}
+
 // Initialize timeline events sortable functionality
 function initTimelineEventsSortable() {
   // Check if jQuery UI is available
@@ -98,8 +112,10 @@ function initTimelineEventsSortable() {
         Alpine.$data(alpineEl).autoSaveStatus = 'saving';
       }
 
-      // AJAX request to update position using new internal endpoint
-      $.ajax({
+      // AJAX request to update position using new internal endpoint.
+      // Queued so it can't race other reorder requests (see enqueueTimelineReorder).
+      enqueueTimelineReorder(function() {
+        return $.ajax({
         url: '/internal/sort/timeline_events',
         type: 'PATCH',
         contentType: 'application/json',
@@ -143,6 +159,7 @@ function initTimelineEventsSortable() {
 
           showTimelineErrorMessage('Failed to reorder events. Please try again.');
         }
+        });
       });
     },
     stop: function(event, ui) {
@@ -850,15 +867,22 @@ document.addEventListener('DOMContentLoaded', function() {
 
     if (endpoint) {
       event.preventDefault();
-      fetch(endpoint, {
-        method: 'GET',
-        headers: {
-          'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').getAttribute('content')
-        }
-      })
-      .then(() => {
-        moveEventInDOM(eventContainer, endpoint);
-        showSuccessMessage('Event moved successfully!');
+      // Queue the move so rapid, consecutive clicks can't race each other on the
+      // server. Only update the DOM once the server confirms the move persisted.
+      enqueueTimelineReorder(function() {
+        return fetch(endpoint, {
+          method: 'GET',
+          headers: {
+            'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').getAttribute('content')
+          }
+        })
+        .then(response => {
+          if (!response.ok) {
+            throw new Error('Move request failed with status ' + response.status);
+          }
+          moveEventInDOM(eventContainer, endpoint);
+          showSuccessMessage('Event moved successfully!');
+        });
       })
       .catch(error => {
         showErrorMessage('Error moving event. Please try again.');

--- a/app/assets/javascripts/timeline-editor.js
+++ b/app/assets/javascripts/timeline-editor.js
@@ -46,6 +46,41 @@ function enqueueTimelineReorder(taskFn) {
   return result;
 }
 
+// Persist the timeline's full event order. Reads the current DOM order and
+// sends the complete list of event IDs to the server, which authoritatively
+// rewrites every position in one transaction. Both drag-and-drop and the move
+// menu use this, so there is a single, race-proof code path for reordering.
+// The request is queued so overlapping reorders run one-at-a-time (and the last
+// one always reflects the final DOM order).
+function persistTimelineOrder() {
+  const eventsContainer = document.querySelector('.timeline-events-container');
+  if (!eventsContainer) return Promise.resolve();
+
+  const timelineId = eventsContainer.dataset.timelineId;
+  const orderedIds = Array.from(eventsContainer.children)
+    .filter(el =>
+      el.classList.contains('timeline-event-container') &&
+      !el.classList.contains('timeline-event-template'))
+    .map(el => el.dataset.eventId)
+    .filter(id => id && id !== '-1');
+
+  return enqueueTimelineReorder(function() {
+    return fetch('/internal/reorder/timeline_events', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+      },
+      body: JSON.stringify({ timeline_id: timelineId, ordered_ids: orderedIds })
+    }).then(response => {
+      if (!response.ok) {
+        throw new Error('Reorder request failed with status ' + response.status);
+      }
+      return response.json();
+    });
+  });
+}
+
 // Initialize timeline events sortable functionality
 function initTimelineEventsSortable() {
   // Check if jQuery UI is available
@@ -91,76 +126,35 @@ function initTimelineEventsSortable() {
       }
     },
     update: function(event, ui) {
-      const eventId = ui.item.attr('data-event-id');
-      const originalPosition = ui.item.data('original-position');
-
-      // Count only the event containers before this one (not timeline header/rail)
-      const allEvents = $('.timeline-events-container .timeline-event-container:not(.timeline-event-template)');
-      const newPosition = allEvents.index(ui.item);
-
-      if (!eventId) {
-        console.error('Event ID not found');
-        return;
-      }
-
-      // Send the position directly - backend will convert to 1-based indexing
-      const targetPosition = newPosition;
-
-      // Show loading state
+      // jQuery UI has already moved the item in the DOM by this point, so we
+      // just persist the new full ordering of the timeline.
       const alpineEl = document.querySelector('[x-data]');
       if (alpineEl) {
         Alpine.$data(alpineEl).autoSaveStatus = 'saving';
       }
 
-      // AJAX request to update position using new internal endpoint.
-      // Queued so it can't race other reorder requests (see enqueueTimelineReorder).
-      enqueueTimelineReorder(function() {
-        return $.ajax({
-        url: '/internal/sort/timeline_events',
-        type: 'PATCH',
-        contentType: 'application/json',
-        headers: {
-          'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
-        },
-        data: JSON.stringify({
-          content_id: eventId,
-          intended_position: targetPosition
-        }),
-        success: function(data) {
-          console.log('Timeline event position updated successfully:', data);
-
-          // Update Alpine.js save status
+      persistTimelineOrder()
+        .then(data => {
           if (alpineEl) {
             Alpine.$data(alpineEl).autoSaveStatus = 'saved';
-            setTimeout(() => {
-              if (Alpine.$data(alpineEl).autoSaveStatus === 'saved') {
-                Alpine.$data(alpineEl).autoSaveStatus = 'saved';
-              }
-            }, 2000);
           }
-
-          if (data.message) {
-            showTimelineSuccessMessage(data.message);
-          }
-        },
-        error: function(xhr, status, error) {
+          showTimelineSuccessMessage((data && data.message) || 'New position saved');
+        })
+        .catch(error => {
           console.error('Error updating timeline event position:', error);
 
-          // Update Alpine.js save status
           if (alpineEl) {
             Alpine.$data(alpineEl).autoSaveStatus = 'error';
           }
 
-          // Revert to original position
+          // Revert to original position on failure
           const originalPosition = ui.item.data('original-position');
           if (typeof originalPosition !== 'undefined') {
             revertEventPosition(ui.item, originalPosition);
           }
 
           showTimelineErrorMessage('Failed to reorder events. Please try again.');
-        }
         });
-      });
     },
     stop: function(event, ui) {
       // Remove visual feedback
@@ -854,43 +848,39 @@ document.addEventListener('DOMContentLoaded', function() {
 
     if (!eventId || eventId === '-1') return;
 
-    let endpoint = null;
+    let action = null;
     if (event.target.closest('.js-move-event-to-top')) {
-      endpoint = `/plan/timeline_events/${eventId}/move/top`;
+      action = 'top';
     } else if (event.target.closest('.js-move-event-up')) {
-      endpoint = `/plan/timeline_events/${eventId}/move/up`;
+      action = 'up';
     } else if (event.target.closest('.js-move-event-down')) {
-      endpoint = `/plan/timeline_events/${eventId}/move/down`;
+      action = 'down';
     } else if (event.target.closest('.js-move-event-to-bottom')) {
-      endpoint = `/plan/timeline_events/${eventId}/move/bottom`;
+      action = 'bottom';
     }
 
-    if (endpoint) {
-      event.preventDefault();
-      // Queue the move so rapid, consecutive clicks can't race each other on the
-      // server. Only update the DOM once the server confirms the move persisted.
-      enqueueTimelineReorder(function() {
-        return fetch(endpoint, {
-          method: 'GET',
-          headers: {
-            'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').getAttribute('content')
-          }
-        })
-        .then(response => {
-          if (!response.ok) {
-            throw new Error('Move request failed with status ' + response.status);
-          }
-          moveEventInDOM(eventContainer, endpoint);
-          showSuccessMessage('Event moved successfully!');
-        });
-      })
+    if (!action) return;
+
+    event.preventDefault();
+
+    // Move the card in the DOM first, then persist the new full ordering.
+    // persistTimelineOrder reads the resulting DOM order, so the server always
+    // receives the complete, authoritative sequence.
+    const moved = moveEventInDOM(eventContainer, action);
+    if (!moved) return;
+
+    persistTimelineOrder()
+      .then(() => showSuccessMessage('Event moved successfully!'))
       .catch(error => {
+        console.error('Error moving event:', error);
         showErrorMessage('Error moving event. Please try again.');
       });
-    }
   });
 
-  function moveEventInDOM(eventContainer, endpoint) {
+  // Reorder a single event card within the timeline DOM. Returns true if the
+  // card actually moved. The visual move happens synchronously so the caller can
+  // immediately read the new ordering; the scale/shadow animation runs after.
+  function moveEventInDOM(eventContainer, action) {
     const eventsContainer = eventContainer.parentElement;
     const allEvents = Array.from(eventsContainer.children).filter(el =>
       el.classList.contains('timeline-event-container') &&
@@ -898,55 +888,52 @@ document.addEventListener('DOMContentLoaded', function() {
     );
 
     const currentIndex = allEvents.indexOf(eventContainer);
-    let newIndex;
+    let newIndex = currentIndex;
 
     // Determine new position based on action
-    if (endpoint.includes('/top')) {
+    if (action === 'top') {
       newIndex = 0;
-    } else if (endpoint.includes('/bottom')) {
+    } else if (action === 'bottom') {
       newIndex = allEvents.length - 1;
-    } else if (endpoint.includes('/up')) {
+    } else if (action === 'up') {
       newIndex = Math.max(0, currentIndex - 1);
-    } else if (endpoint.includes('/down')) {
+    } else if (action === 'down') {
       newIndex = Math.min(allEvents.length - 1, currentIndex + 1);
     }
 
     // Only move if position actually changes
-    if (newIndex !== currentIndex) {
-      // Add animation class
-      eventContainer.style.transition = 'all 0.3s ease-out';
-      eventContainer.style.transform = 'scale(1.02)';
-      eventContainer.style.boxShadow = '0 10px 25px rgba(0,0,0,0.1)';
+    if (newIndex === currentIndex) return false;
 
-      setTimeout(() => {
-        // Move in DOM
-        if (newIndex === 0) {
-          eventsContainer.insertBefore(eventContainer, allEvents[0]);
-        } else if (newIndex === allEvents.length - 1) {
-          eventsContainer.appendChild(eventContainer);
-        } else {
-          const referenceEvent = allEvents[newIndex];
-          if (currentIndex < newIndex) {
-            eventsContainer.insertBefore(eventContainer, referenceEvent.nextSibling);
-          } else {
-            eventsContainer.insertBefore(eventContainer, referenceEvent);
-          }
-        }
-
-        // Reset animation
-        setTimeout(() => {
-          eventContainer.style.transform = 'scale(1)';
-          eventContainer.style.boxShadow = '';
-
-          setTimeout(() => {
-            eventContainer.style.transition = '';
-          }, 300);
-        }, 50);
-
-        // Scroll into view
-        eventContainer.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      }, 150);
+    // Move in DOM synchronously
+    if (newIndex === 0) {
+      eventsContainer.insertBefore(eventContainer, allEvents[0]);
+    } else if (newIndex === allEvents.length - 1) {
+      eventsContainer.appendChild(eventContainer);
+    } else {
+      const referenceEvent = allEvents[newIndex];
+      if (currentIndex < newIndex) {
+        eventsContainer.insertBefore(eventContainer, referenceEvent.nextSibling);
+      } else {
+        eventsContainer.insertBefore(eventContainer, referenceEvent);
+      }
     }
+
+    // Animate the moved card
+    eventContainer.style.transition = 'all 0.3s ease-out';
+    eventContainer.style.transform = 'scale(1.02)';
+    eventContainer.style.boxShadow = '0 10px 25px rgba(0,0,0,0.1)';
+    setTimeout(() => {
+      eventContainer.style.transform = 'scale(1)';
+      eventContainer.style.boxShadow = '';
+      setTimeout(() => {
+        eventContainer.style.transition = '';
+      }, 300);
+    }, 50);
+
+    // Scroll into view
+    eventContainer.scrollIntoView({ behavior: 'smooth', block: 'center' });
+
+    return true;
   }
 
   // Global function for unlinking from sidebar

--- a/app/controllers/timeline_events_controller.rb
+++ b/app/controllers/timeline_events_controller.rb
@@ -1,7 +1,6 @@
 class TimelineEventsController < ApplicationController
   before_action :set_timeline_event, only: [
     :show, :edit, :update, :destroy,
-    :move_up, :move_to_top, :move_down, :move_to_bottom,
     :link_entity, :unlink_entity, :add_tag, :remove_tag
   ]
 
@@ -129,52 +128,47 @@ class TimelineEventsController < ApplicationController
     end
   end
 
-  # Move functions
-  def move_up
-    reorder_timeline_event { @timeline_event.move_higher }
-  end
+  # Reorder endpoint (internal API). Accepts the full, authoritative ordering of
+  # a timeline's events and rewrites every position in a single transaction.
+  #
+  # Both drag-and-drop and the move menu funnel through here. Rewriting the whole
+  # sequence at once (rather than asking acts_as_list to shuffle one row at a
+  # time) makes the operation idempotent and immune to the races that previously
+  # left events with duplicate/garbled positions: whatever order the client
+  # sends last simply wins, as a clean 1..N sequence.
+  def reorder
+    return render json: { error: 'Not authorized' }, status: :forbidden unless user_signed_in?
 
-  def move_down
-    reorder_timeline_event { @timeline_event.move_lower }
-  end
+    timeline = current_user.timelines.find_by(id: params[:timeline_id])
+    return render json: { error: 'Timeline not found' }, status: :not_found unless timeline
 
-  def move_to_top
-    reorder_timeline_event { @timeline_event.move_to_top }
-  end
+    ordered_ids = Array(params[:ordered_ids]).map(&:to_i)
+    events_by_id = timeline.timeline_events.index_by(&:id)
 
-  def move_to_bottom
-    reorder_timeline_event { @timeline_event.move_to_bottom }
-  end
+    position = 0
+    TimelineEvent.transaction do
+      # Apply the client-provided order first.
+      ordered_ids.each do |id|
+        event = events_by_id.delete(id)
+        next unless event
 
-  # Drag and drop sorting endpoint (internal API)
-  def sort
-    content_id = params[:content_id]
-    intended_position = params[:intended_position].to_i
-    
-    timeline_event = TimelineEvent.find_by(id: content_id)
-    
-    unless timeline_event
-      render json: { error: "Timeline event not found" }, status: :not_found
-      return
+        position += 1
+        # update_column writes the position directly, skipping acts_as_list's
+        # shuffle callbacks (we are assigning the entire sequence ourselves).
+        event.update_column(:position, position)
+      end
+
+      # Defensively place any events the client didn't mention after the rest,
+      # preserving their existing order, so positions stay a clean 1..N.
+      events_by_id.values.sort_by { |e| [e.position || Float::INFINITY, e.id] }.each do |event|
+        position += 1
+        event.update_column(:position, position)
+      end
+
+      timeline.touch
     end
-    
-    unless timeline_event.can_be_modified_by?(current_user)
-      render json: { error: "You don't have permission to reorder that timeline event" }, status: :forbidden
-      return
-    end
-    
-    # Use acts_as_list to move to the intended position
-    timeline_event.insert_at(intended_position + 1) # acts_as_list is 1-indexed
-    
-    render json: { 
-      success: true, 
-      message: "New position saved", # "Timeline event moved to position #{intended_position + 1}"
-      timeline_event: {
-        id: timeline_event.id,
-        position: timeline_event.position,
-        title: timeline_event.title
-      }
-    }, status: :ok
+
+    render json: { status: 'success', message: 'New position saved' }
   end
 
   def add_tag
@@ -239,25 +233,6 @@ class TimelineEventsController < ApplicationController
   end
 
   private
-
-  # Shared helper for the move_* actions. Authorizes the change, performs the
-  # acts_as_list move, and renders a JSON result so the client can confirm the
-  # new order actually persisted. Previously these actions rendered no template,
-  # which raised MissingTemplate (HTTP 500) even when the move succeeded, so the
-  # client could never tell a real failure from a success.
-  def reorder_timeline_event
-    unless @timeline_event.can_be_modified_by?(current_user)
-      return render json: { error: "You don't have permission to reorder that timeline event" }, status: :forbidden
-    end
-
-    yield
-
-    render json: {
-      status: 'success',
-      message: 'New position saved',
-      timeline_event: { id: @timeline_event.id, position: @timeline_event.reload.position }
-    }
-  end
 
   # Use callbacks to share common setup or constraints between actions.
   def set_timeline_event

--- a/app/controllers/timeline_events_controller.rb
+++ b/app/controllers/timeline_events_controller.rb
@@ -131,19 +131,19 @@ class TimelineEventsController < ApplicationController
 
   # Move functions
   def move_up
-    @timeline_event.move_higher if @timeline_event.can_be_modified_by?(current_user)
+    reorder_timeline_event { @timeline_event.move_higher }
   end
 
   def move_down
-    @timeline_event.move_lower if @timeline_event.can_be_modified_by?(current_user)
+    reorder_timeline_event { @timeline_event.move_lower }
   end
 
   def move_to_top
-    @timeline_event.move_to_top if @timeline_event.can_be_modified_by?(current_user)
+    reorder_timeline_event { @timeline_event.move_to_top }
   end
 
   def move_to_bottom
-    @timeline_event.move_to_bottom if @timeline_event.can_be_modified_by?(current_user)
+    reorder_timeline_event { @timeline_event.move_to_bottom }
   end
 
   # Drag and drop sorting endpoint (internal API)
@@ -239,6 +239,25 @@ class TimelineEventsController < ApplicationController
   end
 
   private
+
+  # Shared helper for the move_* actions. Authorizes the change, performs the
+  # acts_as_list move, and renders a JSON result so the client can confirm the
+  # new order actually persisted. Previously these actions rendered no template,
+  # which raised MissingTemplate (HTTP 500) even when the move succeeded, so the
+  # client could never tell a real failure from a success.
+  def reorder_timeline_event
+    unless @timeline_event.can_be_modified_by?(current_user)
+      return render json: { error: "You don't have permission to reorder that timeline event" }, status: :forbidden
+    end
+
+    yield
+
+    render json: {
+      status: 'success',
+      message: 'New position saved',
+      timeline_event: { id: @timeline_event.id, position: @timeline_event.reload.position }
+    }
+  end
 
   # Use callbacks to share common setup or constraints between actions.
   def set_timeline_event

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -389,12 +389,6 @@ Rails.application.routes.draw do
       post :toggle_favorite, on: :member
     end
     resources :timeline_events do
-      scope '/move', as: :move do
-        get 'up',     to: 'timeline_events#move_up',        on: :member
-        get 'down',   to: 'timeline_events#move_down',      on: :member
-        get 'top',    to: 'timeline_events#move_to_top',    on: :member
-        get 'bottom', to: 'timeline_events#move_to_bottom', on: :member
-      end
       post 'link',              to: 'timeline_events#link_entity',    on: :member
       post 'unlink/:entity_id', to: 'timeline_events#unlink_entity',  on: :member, as: :unlink_entity
       post 'tags',              to: 'timeline_events#add_tag',        on: :member, as: :add_tag
@@ -429,7 +423,7 @@ Rails.application.routes.draw do
     patch '/universe_field_update/:field_id', to: 'content#universe_field_update', as: :universe_field_update
     patch '/sort/categories',                 to: 'attribute_categories#sort',     as: :sort_categories_internal
     patch '/sort/fields',                     to: 'attribute_fields#sort',         as: :sort_fields_internal
-    patch '/sort/timeline_events',            to: 'timeline_events#sort',          as: :sort_timeline_events_internal
+    patch '/reorder/timeline_events',         to: 'timeline_events#reorder',       as: :reorder_timeline_events_internal
   end
 
   get 'search/', to: 'search#results'

--- a/test/controllers/timeline_events_reorder_test.rb
+++ b/test/controllers/timeline_events_reorder_test.rb
@@ -1,0 +1,99 @@
+require 'test_helper'
+
+# Covers the internal reorder endpoint (TimelineEventsController#reorder), which
+# both drag-and-drop and the move menu use. The endpoint receives the full,
+# authoritative ordering of a timeline's events and rewrites every position as a
+# clean 1..N sequence in one transaction, so it is idempotent and immune to the
+# races that previously left events with duplicate/garbled positions.
+class TimelineEventsReorderTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @owner = users(:one)
+    @other = users(:two)
+
+    @timeline = Timeline.create!(name: "Test Timeline", user: @owner)
+    # Timeline#initialize_first_event already created one event on create; add a
+    # few more so we have a meaningful order to shuffle.
+    3.times { |i| @timeline.timeline_events.create!(title: "Event #{i}") }
+
+    @event_ids = ordered_event_ids
+    assert_equal 4, @event_ids.length, "Setup expects four events to reorder"
+  end
+
+  # Event ids in their stored (position-ascending) order.
+  def ordered_event_ids
+    @timeline.timeline_events.reload.map(&:id)
+  end
+
+  def stored_positions
+    @timeline.timeline_events.reload.map(&:position)
+  end
+
+  def reorder(ordered_ids)
+    patch reorder_timeline_events_internal_path,
+          params: { timeline_id: @timeline.id, ordered_ids: ordered_ids },
+          as: :json
+  end
+
+  test "rewrites positions to match the submitted order as a clean 1..N sequence" do
+    sign_in @owner
+    desired = @event_ids.reverse
+
+    reorder(desired)
+
+    assert_response :success
+    assert_equal desired, ordered_event_ids
+    assert_equal (1..desired.length).to_a, stored_positions
+  end
+
+  test "is idempotent and normalizes duplicate/garbled positions" do
+    sign_in @owner
+    # Simulate the corruption this endpoint is meant to heal: force every event
+    # to share the same position.
+    @timeline.timeline_events.each { |event| event.update_column(:position, 1) }
+
+    desired = @event_ids
+    reorder(desired)
+    reorder(desired) # run twice to prove a repeated call changes nothing
+
+    assert_response :success
+    assert_equal desired, ordered_event_ids
+    assert_equal (1..desired.length).to_a, stored_positions
+  end
+
+  test "appends events omitted from the payload after the provided ones" do
+    sign_in @owner
+    moved = @event_ids.last
+
+    # Mention only the last event; the other three are omitted from the payload.
+    reorder([moved])
+
+    assert_response :success
+    result = ordered_event_ids
+
+    assert_equal moved, result.first, "Provided event should be placed first"
+    assert_equal @event_ids.length, result.length, "No events should be dropped"
+    assert_equal (1..@event_ids.length).to_a, stored_positions, "Positions stay a unique 1..N"
+    assert_equal (@event_ids - [moved]), result[1..], "Omitted events keep their relative order"
+  end
+
+  test "rejects reordering a timeline the user does not own" do
+    sign_in @other
+    original = ordered_event_ids
+
+    reorder(@event_ids.reverse)
+
+    assert_response :not_found
+    assert_equal original, ordered_event_ids, "Order must be unchanged"
+  end
+
+  test "rejects reordering when not signed in" do
+    original = ordered_event_ids
+
+    reorder(@event_ids.reverse)
+
+    assert_response :forbidden
+    assert_equal original, ordered_event_ids, "Order must be unchanged"
+  end
+end


### PR DESCRIPTION
Fixes #

## Changes proposed

- **Replaced individual move operations with atomic reorder endpoint**: Removed the `/move/up`, `/move/down`, `/move/top`, and `/move/to_bottom` endpoints that used `acts_as_list` to shuffle positions one at a time. These operations could race when executed in parallel, leaving events with duplicate or garbled positions.

- **Implemented transactional reorder operation**: Added a new `/internal/reorder/timeline_events` endpoint that accepts the complete, authoritative ordering of all events in a timeline and rewrites every position in a single database transaction. This makes the operation idempotent and immune to race conditions.

- **Unified drag-and-drop and move menu through single code path**: Both the jQuery UI sortable drag-and-drop and the move menu buttons now funnel through `persistTimelineOrder()`, which reads the current DOM order and sends it to the server. This ensures a single, race-proof reordering mechanism.

- **Added request serialization**: Implemented `enqueueTimelineReorder()` to serialize concurrent reorder requests, ensuring they execute one-at-a-time. This prevents overlapping requests from interleaving their position updates on the server.

- **Simplified DOM manipulation**: Refactored `moveEventInDOM()` to perform synchronous DOM moves and animations without making server requests, then delegate persistence to `persistTimelineOrder()`. This separates concerns and makes the UI more responsive.

## Technical Details

The root cause of the bug was that parallel move requests could have their position shuffles interleave on the server. For example, if two events were moved simultaneously, the database could end up with both events at the same position or with gaps in the sequence.

The fix works by:
1. Always sending the complete event ordering from the client (read from DOM)
2. Processing it in a single database transaction that assigns positions 1..N
3. Serializing requests so only one reorder runs at a time
4. Handling any events the client didn't mention by placing them after the rest

This approach is much simpler and more robust than trying to coordinate individual position changes.

@indentlabs/contributors

https://claude.ai/code/session_01QPKRxtr91aePQYZm88iijC