### PR TITLE
Allow image uploads attributes in content params

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -964,7 +964,13 @@ class ContentController < ApplicationController
       .downcase
       .to_sym
 
-    params.require(content_class).except(:page_tags, :_destroy).permit(content_param_list + [:deleted_at, :document_entity_id])
+    params.require(content_class).except(:page_tags, :_destroy).permit(
+      content_param_list + [
+        :deleted_at,
+        :document_entity_id,
+        { image_uploads_attributes: [:id, :src, :privacy, :_destroy] }
+      ]
+    )
   end
 
   def page_tag_params


### PR DESCRIPTION
Fixes #

Changes proposed:

- Add `image_uploads_attributes` to the permitted parameters in `content_params` method
- Allow nested attributes for image uploads including `:id`, `:src`, `:privacy`, and `:_destroy`
- Enables proper handling of image upload modifications when creating or updating content pages

This change permits the image uploads association to be properly mass-assigned when processing content parameters, allowing users to upload, modify, and delete images associated with content pages through the standard Rails nested attributes pattern.

@indentlabs/contributors

https://claude.ai/code/session_015QAakAFyx1QrdUP8Zn1wG2