### PR TITLE
Fix nil word_count crash in word count updates index

### DIFF
--- a/app/views/word_count_updates/index.html.erb
+++ b/app/views/word_count_updates/index.html.erb
@@ -185,14 +185,15 @@
                       <div class="flex items-center space-x-4">
                         <!-- Value Display -->
                         <div x-show="!editing" class="text-right">
+                          <% word_count = update.word_count || 0 %>
                           <% if update.is_manual_adjustment? %>
-                            <div class="text-sm font-bold <%= update.word_count > 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400' %>">
-                              <%= update.word_count > 0 ? '+' : '' %><%= number_with_delimiter update.word_count %> words
+                            <div class="text-sm font-bold <%= word_count > 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400' %>">
+                              <%= word_count > 0 ? '+' : '' %><%= number_with_delimiter word_count %> words
                             </div>
                             <div class="text-xs text-gray-500 dark:text-gray-400">delta</div>
                           <% else %>
                             <div class="text-sm font-bold text-gray-700 dark:text-gray-300">
-                              <%= number_with_delimiter update.word_count %>
+                              <%= number_with_delimiter word_count %>
                             </div>
                             <div class="text-xs text-gray-500 dark:text-gray-400">total document size</div>
                           <% end %>

--- a/test/controllers/word_count_updates_controller_test.rb
+++ b/test/controllers/word_count_updates_controller_test.rb
@@ -1,0 +1,64 @@
+require 'test_helper'
+
+class WordCountUpdatesControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @user = users(:one)
+    @document = Document.create!(title: 'Test Document', body: 'Test content', user: @user)
+  end
+
+  test "should redirect to login when not authenticated" do
+    get word_count_updates_path
+    assert_redirected_to new_user_session_path
+  end
+
+  test "index renders successfully with manual adjustments" do
+    sign_in @user
+    WordCountUpdate.create!(
+      user: @user,
+      entity_type: 'ManualAdjustment',
+      entity_id: 1,
+      word_count: 500,
+      for_date: Date.current
+    )
+
+    get word_count_updates_path
+    assert_response :success
+  end
+
+  # Regression test: a legacy/dirty manual-adjustment row with a nil word_count
+  # used to crash the page with a 500 because the view evaluated
+  # `update.word_count > 0`. The view must tolerate nil and render fine.
+  test "index renders when a manual adjustment has a nil word_count" do
+    sign_in @user
+    record = WordCountUpdate.create!(
+      user: @user,
+      entity_type: 'ManualAdjustment',
+      entity_id: 2,
+      word_count: 0,
+      for_date: Date.current
+    )
+    # Bypass the before_validation normalization to simulate a pre-existing
+    # nil row in the database.
+    record.update_column(:word_count, nil)
+
+    get word_count_updates_path
+    assert_response :success
+  end
+
+  test "create stores a manual adjustment" do
+    sign_in @user
+    assert_difference('WordCountUpdate.count', 1) do
+      post word_count_updates_path, params: { word_count_update: { for_date: Date.current, word_count: 250 } }
+    end
+    assert_redirected_to word_count_updates_path
+  end
+
+  test "create with blank word count stores zero instead of nil" do
+    sign_in @user
+    post word_count_updates_path, params: { word_count_update: { for_date: Date.current, word_count: '' } }
+    assert_redirected_to word_count_updates_path
+    assert_equal 0, @user.word_count_updates.last.word_count
+  end
+end


### PR DESCRIPTION
Fixes # (regression in word count updates display)

Changes proposed:

- Add defensive nil-coalescing in the word count updates index view to handle legacy database records with nil word_count values
- Store a local variable `word_count = update.word_count || 0` before conditional checks to prevent crashes when word_count is nil
- Apply the safe word_count variable consistently across both manual adjustment and document update display paths

The view previously crashed with a 500 error when evaluating `update.word_count > 0` on records with nil word_count values. This could occur with pre-existing manual adjustment rows in the database. The fix ensures the view gracefully handles nil values by treating them as 0.

Added comprehensive test coverage:
- Regression test verifying the index renders successfully when a manual adjustment has a nil word_count
- Tests for manual adjustment creation with valid and blank word counts
- Tests for authentication and authorization

@indentlabs/contributors

https://claude.ai/code/session_01JEreFy2qhcGh6UQQRb395P