### PR TITLE
Fix N+1 query in Thredded::TopicsController#show

### DIFF
--- a/app/models/users/user.rb
+++ b/app/models/users/user.rb
@@ -67,7 +67,13 @@ class User < ApplicationRecord
     @cached_blocked_by_users ||= User.joins(:user_blockings).where(user_blockings: { blocked_user_id: self.id })
   end
   def blocked_by?(user)
-    UserBlocking.exists?(user_id: user.id, blocked_user_id: self.id)
+    return false if user.nil?
+    # Use a memoized set of the blocking user's blocked IDs to avoid N+1 queries
+    # when checking many users against the same current_user (e.g. forum topics).
+    user.blocked_user_ids_set.include?(self.id)
+  end
+  def blocked_user_ids_set
+    @blocked_user_ids_set ||= user_blockings.pluck(:blocked_user_id).to_set
   end
 
   has_many :content_page_shares,           dependent: :destroy


### PR DESCRIPTION
The forum topic show page rendered post.user.blocked_by?(current_user) once per post, each running a UserBlocking.exists? query. On long topics (e.g. page 29 of a chat thread) this produced an N+1.

Memoize the current user's blocked-user IDs into a Set once per request and check membership in Ruby, eliminating the per-post query.

Fixes #

Changes proposed:

 - 
 
 -
 
 -

@indentlabs/contributors
