### PR TITLE
Fix NoMethodError on usage analytics page for users with no content

### DIFF
--- a/app/views/data/usage.html.erb
+++ b/app/views/data/usage.html.erb
@@ -109,7 +109,7 @@
             end
           %>
           <h3 class="text-2xl font-bold mt-1 truncate">
-            <%= most_active_type.pluralize %>
+            <%= most_active_type ? most_active_type.pluralize : "None yet" %>
           </h3>
         </div>
         <div class="bg-white bg-opacity-20 rounded-full p-2">
@@ -117,7 +117,11 @@
         </div>
       </div>
       <div class="mt-4 text-sm text-amber-100">
-        <span class="font-medium"><%= number_with_delimiter most_active_count %> pages</span> of this type
+        <% if most_active_type %>
+          <span class="font-medium"><%= number_with_delimiter most_active_count %> <%= 'page'.pluralize(most_active_count) %></span> of this type
+        <% else %>
+          Create a page to see your most active type
+        <% end %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fixes #

Changes proposed:

 - Guard the "Most Active Content" card in `app/views/data/usage.html.erb` against `nil` — `most_active_type.pluralize` raised `NoMethodError: undefined method 'pluralize' for nil:NilClass` when a user had no pages yet; the heading now falls back to "None yet"

 - Update the card footer to show "Create a page to see your most active type" in the empty state instead of "0 pages of this type"

 - Correctly pluralize "page"/"pages" in the card footer based on the page count

@indentlabs/contributors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUf8xy2GrWdJGtpWGFFUZr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUf8xy2GrWdJGtpWGFFUZr)_