### PR TITLE
Fix NoMethodError in BasilController#commission for fields missing label/value

### DIFF
--- a/app/controllers/basil_controller.rb
+++ b/app/controllers/basil_controller.rb
@@ -676,14 +676,18 @@ class BasilController < ApplicationController
     # Prepare our prompt components
     prompt_components = []
     commission_params.fetch(:field).each do |field_id, field_data|
-      label      = field_data[:label].strip
-      value      = field_data[:value].gsub(',',  '')
+      label      = field_data[:label].to_s.strip
+      value      = field_data[:value].to_s
+                                     .gsub(',',  '')
                                      .gsub("\r", '')
                                      .gsub('(',  '')
                                      .gsub(')',  '')
                                      .gsub("\n", ' ')
                                      .strip
       importance = field_data[:importance].to_f
+
+      # Skip fields that didn't submit a label or value at all
+      next if label.empty? && value.empty?
 
       # Field skips
       next if label_value_pairs_to_skip_entirely.include?([label.downcase, value.downcase])

--- a/test/controllers/basil_controller_test.rb
+++ b/test/controllers/basil_controller_test.rb
@@ -16,4 +16,28 @@ class BasilControllerTest < ActionDispatch::IntegrationTest
   #   get basil_content_url(content_type: 'Character', id: characters(:one).id)
   #   assert_response :success
   # end
+
+  test "commission tolerates fields missing a label or value" do
+    current_user = user(:starter)
+    sign_in current_user
+    character = Character.create!(user: current_user, name: 'Basil Test Character')
+
+    assert_difference 'BasilCommission.count', 1 do
+      post basil_commission_url(content_type: 'Character', id: character.id), params: {
+        basil_commission: {
+          entity_type: 'Character',
+          entity_id:   character.id,
+          field: {
+            '1' => { value: 'blue', importance: '1' },
+            '2' => { label: 'Hair', importance: '1' },
+            '3' => { importance: '1' },
+            '4' => { label: 'Eyes', value: 'green', importance: '1' }
+          }
+        }
+      }
+    end
+
+    assert_redirected_to basil_content_path('Character', character.id)
+    assert_equal 'blue, Hair, green Eyes', BasilCommission.last.prompt
+  end
 end


### PR DESCRIPTION
Fixes #

Changes proposed:

 - Coerce `field_data[:label]` and `field_data[:value]` to strings in `BasilController#commission` before calling `.strip`/`.gsub`, fixing the `NoMethodError: undefined method 'strip' for nil:NilClass` raised when a submitted field entry omits its label (or value) — `commission_params` permits `field: {}` as an open hash, so those keys aren't guaranteed
 
 - Skip field entries that provide neither a label nor a value, so they no longer contribute empty components to the generated prompt
 
 - Add a regression test that posts a commission with field entries missing `label`, `value`, and both; it reproduces the reported crash on the unpatched controller and asserts the generated prompt only includes meaningful components

@indentlabs/contributors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBQMNjXtn8F4DpKXnUs8ey

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBQMNjXtn8F4DpKXnUs8ey)_