### PR TITLE
Fix nil reference error in content page share deletion check

### DIFF
--- a/app/views/content_page_shares/show.html.erb
+++ b/app/views/content_page_shares/show.html.erb
@@ -108,7 +108,7 @@
 
                     <div class="border-t border-gray-100 dark:border-gray-700 my-1"></div>
 
-                    <% if @share.user == current_user || current_user.site_administrator? %>
+                    <% if @share.user == current_user || current_user&.site_administrator? %>
                       <%= link_to user_content_page_share_path(user_id: @share.user.id, id: @share.id),
                           method: :DELETE,
                           data: { confirm: "Are you sure? This will delete this share and any comments!" },


### PR DESCRIPTION
Fixes #

Changes proposed:

- Add safe navigation operator (`&.`) to `current_user.site_administrator?` call in content page share view to prevent nil reference errors when `current_user` is nil

This change prevents a potential NoMethodError when checking if the current user is a site administrator. The safe navigation operator ensures that if `current_user` is nil, the expression short-circuits and returns nil instead of attempting to call `site_administrator?` on a nil object.

@indentlabs/contributors

https://claude.ai/code/session_01VBDEmLHgzwmcJJRZi8zAqr