### PR TITLE
Fix redirect handling in page collections controller

### DIFF
--- a/app/controllers/page_collections_controller.rb
+++ b/app/controllers/page_collections_controller.rb
@@ -111,6 +111,8 @@ class PageCollectionsController < ApplicationController
   Rails.application.config.content_types[:all].each do |content_type|
     define_method(content_type.name.downcase.pluralize.to_sym) do
       set_page_collection
+      return if performed?
+
       set_submittable_content
 
       @show_page_type_highlight = true
@@ -172,7 +174,9 @@ class PageCollectionsController < ApplicationController
   # AJAX endpoint for infinite scrolling
   def pages
     set_page_collection
-    
+    return if performed?
+
+
     unless (@page_collection.privacy == 'public' || (user_signed_in? && @page_collection.user == current_user))
       return render json: { error: "Not authorized" }, status: :unauthorized
     end

--- a/test/controllers/page_collections_controller_test.rb
+++ b/test/controllers/page_collections_controller_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class PageCollectionsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @user = users(:one)
+  end
+
+  test "content type action redirects when collection does not exist" do
+    sign_in @user
+
+    get characters_page_collection_path(id: 'card-headers')
+
+    assert_redirected_to root_path
+    assert_equal 'Collection not found!', flash[:notice]
+  end
+
+  test "pages action redirects when collection does not exist" do
+    sign_in @user
+
+    get pages_page_collection_path(id: 'card-headers')
+
+    assert_redirected_to root_path
+    assert_equal 'Collection not found!', flash[:notice]
+  end
+end


### PR DESCRIPTION
Fixes #

Changes proposed:

- Add early return checks in `PageCollectionsController` after `set_page_collection` to prevent further processing when a redirect has already been performed
- Apply fix to dynamically generated content type actions (e.g., `characters`, `locations`) in the `explore` block
- Apply fix to the `pages` AJAX endpoint for infinite scrolling
- Add integration tests to verify that both content type and pages actions properly redirect with a flash notice when a collection does not exist

The `set_page_collection` method performs a redirect when a collection is not found, but the controller actions were continuing to execute after the redirect. By checking `performed?` and returning early, we prevent subsequent code from running after the redirect has been issued.

@indentlabs/contributors

https://claude.ai/code/session_01X8ssUAB8649BrvzRBnvnwJ