### PR TITLE
Fix nil reference error in feed item dropdown menu

### DIFF
--- a/app/views/stream/_feed_item.html.erb
+++ b/app/views/stream/_feed_item.html.erb
@@ -58,7 +58,7 @@
         <!-- Dropdown Menu -->
         <div data-dropdown-target="menu" class="hidden absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 rounded-md shadow-lg py-1 ring-1 ring-black ring-opacity-5 focus:outline-none z-10 border border-gray-200 dark:border-gray-700">
           <%= link_to "View details", [share.user, share], class: "block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700" %>
-          <% if current_user == share.user || current_user.site_administrator? %>
+          <% if current_user == share.user || current_user&.site_administrator? %>
             <%= link_to "Delete", [share.user, share], method: :delete, data: { confirm: "Are you sure?" }, class: "block px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700" %>
           <% end %>
           <% if current_user != share.user %>


### PR DESCRIPTION
Fixes #

Changes proposed:

- Add safe navigation operator (`&.`) to `current_user.site_administrator?` call in feed item dropdown menu to prevent nil reference errors when `current_user` is nil

This change prevents a NoMethodError that would occur when an unauthenticated user (where `current_user` is nil) views a feed item. The safe navigation operator allows the condition to gracefully evaluate to false instead of raising an exception.

@indentlabs/contributors

https://claude.ai/code/session_019rHFG7pYHpRi99SBeoRqup