### PR TITLE
Refactor content page type labels into reusable helper method

### DIFF
--- a/app/controllers/content_page_shares_controller.rb
+++ b/app/controllers/content_page_shares_controller.rb
@@ -47,7 +47,7 @@ class ContentPageSharesController < ApplicationController
       # Notify the content creator if they're different from the sharer
       content_owner = @share.content_page.user
       if content_owner != current_user && content_owner.notification_updates?
-        content_type_name = @share.content_page.class.name.downcase
+        content_type_name = @share.content_page_type_label
         content_type_color = @share.content_page.class.respond_to?(:color) ? @share.content_page.class.color : 'bg-blue-500'
 
         content_owner.notifications.create(

--- a/app/jobs/content_page_share_notification_job.rb
+++ b/app/jobs/content_page_share_notification_job.rb
@@ -13,7 +13,7 @@ class ContentPageShareNotificationJob < ApplicationJob
       next if comment.user == following.user
 
       following.user.notifications.create(
-        message_html:     "<div><span class='#{User.text_color}'>#{comment.user.display_name}</span> commented on #{comment.user == comment.content_page_share.content_page.user ? 'the' : 'your'} shared #{comment.content_page_share.content_page.class.name.downcase} <span class='#{comment.content_page_share.content_page.class.text_color}'>#{comment.content_page_share.content_page.name}</span>.</div>",
+        message_html:     "<div><span class='#{User.text_color}'>#{comment.user.display_name}</span> commented on #{comment.user == comment.content_page_share.content_page.user ? 'the' : 'your'} shared #{comment.content_page_share.content_page_type_label} <span class='#{comment.content_page_share.content_page.class.text_color}'>#{comment.content_page_share.content_page.name}</span>.</div>",
         icon:             comment.content_page_share.content_page.class.icon,
         icon_color:       comment.content_page_share.content_page.class.color,
         happened_at:      DateTime.current,

--- a/app/models/stream/content_page_share.rb
+++ b/app/models/stream/content_page_share.rb
@@ -14,6 +14,23 @@ class ContentPageShare < ApplicationRecord
     user.content_page_share_followings.create({content_page_share: self})
   end
 
+  # Human-readable label for the shared page's type, e.g. "character" or
+  # "topic" (rather than raw class names like "Thredded::Topic").
+  def content_page_type_label
+    self.class.page_type_label(content_page)
+  end
+
+  def secondary_content_page_type_label
+    self.class.page_type_label(secondary_content_page)
+  end
+
+  def self.page_type_label(page)
+    return 'page' if page.nil?
+    return page.class.content_name if page.class.respond_to?(:content_name)
+
+    page.class.name.demodulize.underscore.humanize.downcase
+  end
+
   def followed_by?(user)
     return false if user.nil?
     

--- a/app/views/content_page_shares/_stream_added_to_page_collection.html.erb
+++ b/app/views/content_page_shares/_stream_added_to_page_collection.html.erb
@@ -9,7 +9,7 @@
         <%= share.user.display_name %>
       <% end %>
       <% if share.user == content.user %>
-        added a <%= share.secondary_content_page.class.name.downcase %> to their
+        added a <%= share.secondary_content_page_type_label %> to their
       <% else %>
         got accepted into the
       <% end %>

--- a/app/views/content_page_shares/show.html.erb
+++ b/app/views/content_page_shares/show.html.erb
@@ -36,11 +36,11 @@
                       <span class="text-gray-500 dark:text-gray-400">shared a</span>
                       <% if @share.content_page.class.respond_to?(:hex_color) %>
                         <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium" style="background-color: <%= @share.content_page.class.hex_color %>20; color: <%= @share.content_page.class.hex_color %>;">
-                          <%= @share.content_page.class.name.downcase %>
+                          <%= @share.content_page_type_label %>
                         </span>
                       <% else %>
                         <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300">
-                          <%= @share.content_page.class.name.downcase %>
+                          <%= @share.content_page_type_label %>
                         </span>
                       <% end %>
                     <% else %>
@@ -182,7 +182,7 @@
                           <svg class="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/>
                           </svg>
-                          View <%= @share.content_page.class.name.downcase %>
+                          View <%= @share.content_page_type_label %>
                         </span>
                         <% if @share.content_page.respond_to?(:privacy) && @share.content_page.privacy == 'public' %>
                           <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-300">

--- a/app/views/stream/_feed_item.html.erb
+++ b/app/views/stream/_feed_item.html.erb
@@ -23,11 +23,11 @@
               <span class="text-gray-500 dark:text-gray-400">shared a</span>
               <% if share.content_page.class.respond_to?(:hex_color) %>
                 <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium" style="background-color: <%= share.content_page.class.hex_color %>20; color: <%= share.content_page.class.hex_color %>;">
-                  <%= share.content_page.class.name.downcase %>
+                  <%= share.content_page_type_label %>
                 </span>
               <% else %>
                 <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300">
-                  <%= share.content_page.class.name.downcase %>
+                  <%= share.content_page_type_label %>
                 </span>
               <% end %>
             <% else %>

--- a/lib/extensions/thredded/topic.rb
+++ b/lib/extensions/thredded/topic.rb
@@ -13,6 +13,10 @@ module Extensions
 
         acts_as_paranoid
 
+        def self.content_name
+          'topic'
+        end
+
         def self.icon
           'forum'
         end


### PR DESCRIPTION
Fixes #

Changes proposed:

- Add `content_page_type_label` and `secondary_content_page_type_label` instance methods to `ContentPageShare` model to provide human-readable labels for shared content types
- Add `self.page_type_label(page)` class method to centralize logic for generating content type labels, with support for custom `content_name` method and fallback to humanized class names
- Add `content_name` method to `Thredded::Topic` extension to return 'topic' as the display name
- Replace all instances of `@share.content_page.class.name.downcase` with `@share.content_page_type_label` in views and controllers for consistency and maintainability
- Update notification job to use the new helper method for generating content type labels in notification messages

This refactoring eliminates code duplication and provides a single source of truth for content type label generation, making it easier to customize labels for different content types in the future.

@indentlabs/contributors

https://claude.ai/code/session_01NnQ2S4F65CFm8uRdLbU43c