### PR TITLE
Improve comment UX with user links, timestamps, and delete functionality

### DIFF
--- a/app/controllers/share_comments_controller.rb
+++ b/app/controllers/share_comments_controller.rb
@@ -31,10 +31,9 @@ class ShareCommentsController < ApplicationController
   end
 
   # DELETE /share_comments/1
-  # TODO this
   def destroy
     share = @share_comment.content_page_share
-    unless user_signed_in? && (share.user == current_user || @share_comment.user == current_user)
+    unless user_signed_in? && (share.user == current_user || @share_comment.user == current_user || current_user.site_administrator?)
       return raise "Tried to delete comment without authorization"
     end
 

--- a/app/models/users/user.rb
+++ b/app/models/users/user.rb
@@ -79,6 +79,7 @@ class User < ApplicationRecord
   has_many :content_page_shares,           dependent: :destroy
   has_many :content_page_share_followings, dependent: :destroy
   has_many :content_page_share_reports,    dependent: :destroy
+  has_many :share_comments,                dependent: :destroy
 
   has_many :page_collections,              dependent: :destroy
   has_many :page_collection_submissions,   dependent: :destroy

--- a/app/views/content_page_shares/show.html.erb
+++ b/app/views/content_page_shares/show.html.erb
@@ -271,7 +271,9 @@
                 <% @share.share_comments.each do |comment| %>
                   <div class="flex space-x-3">
                     <% if comment.user.present? %>
-                      <%= image_tag comment.user.image_url(size: 32), class: "h-8 w-8 rounded-full flex-shrink-0 border border-green-200" %>
+                      <%= link_to comment.user, class: "flex-shrink-0" do %>
+                        <%= image_tag comment.user.image_url(size: 32), class: "h-8 w-8 rounded-full border border-green-200" %>
+                      <% end %>
                     <% else %>
                       <div class="h-8 w-8 rounded-full flex-shrink-0 bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
                         <i class="material-icons text-gray-400 text-sm">person</i>
@@ -279,13 +281,28 @@
                     <% end %>
                     <div class="flex-1 min-w-0">
                       <div class="bg-gray-50 dark:bg-gray-700 rounded-lg px-3 py-2">
-                        <div class="flex items-center space-x-2 mb-1">
-                          <% if comment.user.present? %>
-                            <span class="font-medium text-sm text-gray-900 dark:text-white"><%= comment.user.display_name %></span>
-                          <% else %>
-                            <span class="font-medium text-sm text-gray-500 dark:text-gray-400">Deleted User</span>
+                        <div class="flex items-center justify-between mb-1">
+                          <div class="flex items-center space-x-2">
+                            <% if comment.user.present? %>
+                              <%= link_to comment.user, class: "font-medium text-sm text-gray-900 dark:text-white hover:text-blue-600 dark:hover:text-blue-400 transition-colors" do %>
+                                <%= comment.user.display_name %>
+                              <% end %>
+                            <% else %>
+                              <span class="font-medium text-sm text-gray-500 dark:text-gray-400">Deleted User</span>
+                            <% end %>
+                            <span class="text-xs text-gray-500 dark:text-gray-400"><%= time_ago_in_words comment.created_at %> ago</span>
+                          </div>
+                          <% if user_signed_in? && (comment.user == current_user || @share.user == current_user || current_user.site_administrator?) %>
+                            <%= link_to share_comment_path(comment),
+                                method: :DELETE,
+                                data: { confirm: "Are you sure you want to delete this comment?" },
+                                title: "Delete comment",
+                                class: "p-1 text-gray-400 dark:text-gray-500 hover:text-red-600 dark:hover:text-red-400 rounded transition-colors" do %>
+                              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+                              </svg>
+                            <% end %>
                           <% end %>
-                          <span class="text-xs text-gray-500 dark:text-gray-400"><%= time_ago_in_words comment.created_at %> ago</span>
                         </div>
                         <div class="text-sm text-gray-700 dark:text-gray-300">
                           <%= simple_format ContentFormatterService.show(text: comment.message, viewing_user: current_user) %>

--- a/app/views/stream/_feed_item.html.erb
+++ b/app/views/stream/_feed_item.html.erb
@@ -151,11 +151,25 @@
         <div class="space-y-4">
           <% share.share_comments.limit(2).each do |comment| %>
             <div class="flex space-x-3">
-              <%= image_tag comment.user.image_url(size: 32), class: "h-8 w-8 rounded-full flex-shrink-0" %>
+              <% if comment.user.present? %>
+                <%= link_to comment.user, class: "flex-shrink-0" do %>
+                  <%= image_tag comment.user.image_url(size: 32), class: "h-8 w-8 rounded-full" %>
+                <% end %>
+              <% else %>
+                <div class="h-8 w-8 rounded-full flex-shrink-0 bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
+                  <i class="material-icons text-gray-400 text-sm">person</i>
+                </div>
+              <% end %>
               <div class="flex-1 min-w-0">
                 <div class="bg-gray-50 dark:bg-gray-700 rounded-lg px-3 py-2">
                   <div class="flex items-center space-x-2 mb-1">
-                    <span class="font-medium text-sm text-gray-900 dark:text-white"><%= comment.user.display_name %></span>
+                    <% if comment.user.present? %>
+                      <%= link_to comment.user, class: "font-medium text-sm text-gray-900 dark:text-white hover:text-blue-600 dark:hover:text-blue-400 transition-colors" do %>
+                        <%= comment.user.display_name %>
+                      <% end %>
+                    <% else %>
+                      <span class="font-medium text-sm text-gray-500 dark:text-gray-400">Deleted User</span>
+                    <% end %>
                     <span class="text-xs text-gray-500 dark:text-gray-400"><%= time_ago_in_words comment.created_at %> ago</span>
                   </div>
                   <div class="text-sm text-gray-700 dark:text-gray-300">

--- a/lib/tasks/daily.rake
+++ b/lib/tasks/daily.rake
@@ -30,6 +30,10 @@ namespace :daily do
     # Destroy all stream comments from blocked users and nil users
     ShareComment.where(user_id: blocked_user_ids).destroy_all
     ShareComment.where(user_id: nil).destroy_all
+
+    # Destroy stream comments left behind by users deleted before comments
+    # cascaded on user deletion (user_id set, but the user is soft-deleted)
+    ShareComment.where(user_id: User.only_deleted.select(:id)).destroy_all
   end
 
   desc "Run end-of-day-analytics reporter"


### PR DESCRIPTION
Fixes #

Changes proposed:

- **Add clickable user profile links** to comment author names and avatars in both the content page share view and feed item view, with hover styling for better discoverability
- **Display comment timestamps** ("X ago") consistently in both views for better context
- **Implement comment deletion** for authorized users (comment author, share owner, or site administrators) with a delete button in the comment header
- **Handle deleted users gracefully** by displaying "Deleted User" placeholder text when a comment's user has been soft-deleted
- **Add cascade delete** for share comments when users are deleted by adding `dependent: :destroy` to the User model association
- **Clean up orphaned comments** in the daily task by destroying share comments left behind by soft-deleted users (where user_id is set but the user record is deleted)
- **Remove TODO comment** from share_comments_controller destroy action and implement proper authorization including site administrator check

@indentlabs/contributors

https://claude.ai/code/session_016Gzff2NBgrkVoUnERqDjXv