### PR TITLE
Migrate email service from SendGrid to Amazon SES

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: "Notebook.ai <hello@notebook.ai>"
   layout 'mailer'
 end

--- a/app/mailers/collaboration_mailer.rb
+++ b/app/mailers/collaboration_mailer.rb
@@ -1,6 +1,4 @@
 class CollaborationMailer < ApplicationMailer
-  default from: "collaboration@notebook.ai"
-
   def contributor_invitation(inviter, invite_email, universe)
     @inviter = inviter
     @universe = universe

--- a/app/mailers/invoices_mailer.rb
+++ b/app/mailers/invoices_mailer.rb
@@ -1,5 +1,5 @@
 class InvoicesMailer < ApplicationMailer
-  default from: "billing@notebook.ai"
+  default from: "Notebook.ai Billing <hello@notebook.ai>"
 
   def dispatch_invoice(user_id)
     @user = User.find_by(id: user_id)

--- a/app/mailers/unsubscribed_mailer.rb
+++ b/app/mailers/unsubscribed_mailer.rb
@@ -1,6 +1,4 @@
 class UnsubscribedMailer < ApplicationMailer
-  default from: "notebook@indentlabs.com"
-
   def unsubscribed(user)
     @user_name  = user.name.presence || 'worldbuilder'
     @user_email = user.email

--- a/app/views/collaboration_mailer/contributor_invitation.html.erb
+++ b/app/views/collaboration_mailer/contributor_invitation.html.erb
@@ -19,7 +19,7 @@
 
     <br /><br /><br />
     <p style="font-size: 80%">
-      Please don't respond to this email as this email address is not watched. If you have any questions, comments, concerns, or want to unsubscribe to future collaboration invitations, please send an email directly to andrew@indentlabs.com. Thank you for your understanding.
+      If you have any questions, comments, concerns, or want to unsubscribe from future collaboration invitations, just reply to this email and we'll take care of it.
     </p>
   </body>
 </html>

--- a/app/views/collaboration_mailer/contributor_invitation.text.erb
+++ b/app/views/collaboration_mailer/contributor_invitation.text.erb
@@ -10,4 +10,4 @@ Happy worldbuilding!
 
 -
 
-Please don't respond to this email as the address is not watched. If you have any questions, comments, concerns, or want to unsubscribe to future collaboration invitations, please send an email directly to andrew@indentlabs.com. Thank you for your understanding.
+If you have any questions, comments, concerns, or want to unsubscribe from future collaboration invitations, just reply to this email and we'll take care of it.

--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -471,7 +471,7 @@
         <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700 p-6">
           <div class="prose text-gray-600 dark:text-gray-300 max-w-none">
             <p>
-              Have a question not answered by anything above? Feel free to send me an email any time at <strong>andrew@indentlabs.com</strong> and I'll get back to you
+              Have a question not answered by anything above? Feel free to send me an email any time at <strong>hello@notebook.ai</strong> and I'll get back to you
               as quickly as possible. I'm always happy to help!
             </p>
             <p>
@@ -480,7 +480,7 @@
           </div>
           
           <div class="mt-6 flex">
-            <a href="mailto:andrew@indentlabs.com" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+            <a href="mailto:hello@notebook.ai" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
               <i class="material-icons mr-2">email</i>
               Contact Support
             </a>

--- a/app/views/help/organizing_with_universes.html.erb
+++ b/app/views/help/organizing_with_universes.html.erb
@@ -439,7 +439,7 @@
             <p class="text-blue-800 dark:text-blue-200 mb-4">
               If you're still having trouble with universes, our support team is here to help!
             </p>
-            <a href="mailto:support@notebook.ai" class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors duration-200">
+            <a href="mailto:hello@notebook.ai" class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors duration-200">
               <i class="material-icons mr-2">email</i>
               Contact Support
             </a>

--- a/app/views/help/page_templates.html.erb
+++ b/app/views/help/page_templates.html.erb
@@ -553,7 +553,7 @@
               <p class="text-blue-100 mb-4">
                 Can't find what you're looking for? Our support team is here to help with any template customization questions.
               </p>
-              <a href="mailto:andrew@indentlabs.com" class="inline-flex items-center px-6 py-3 border border-transparent text-sm font-medium rounded-lg text-blue-600 bg-white hover:bg-blue-50 transition-colors shadow-sm">
+              <a href="mailto:hello@notebook.ai" class="inline-flex items-center px-6 py-3 border border-transparent text-sm font-medium rounded-lg text-blue-600 bg-white hover:bg-blue-50 transition-colors shadow-sm">
                 <i class="material-icons mr-2">email</i>
                 Contact Support
               </a>

--- a/app/views/help/troubleshooting.html.erb
+++ b/app/views/help/troubleshooting.html.erb
@@ -299,7 +299,7 @@
               If your question wasn't answered here, we're happy to help!
             </p>
             <div class="flex flex-wrap gap-3">
-              <a href="mailto:andrew@indentlabs.com" class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors duration-200">
+              <a href="mailto:hello@notebook.ai" class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors duration-200">
                 <i class="material-icons mr-2">email</i>
                 Email Support
               </a>

--- a/app/views/help/your_account.html.erb
+++ b/app/views/help/your_account.html.erb
@@ -231,7 +231,7 @@
           </div>
 
           <p class="text-gray-700 dark:text-gray-300 mb-4">
-            If you wish to delete your Notebook.ai account, please contact us at <strong>andrew@indentlabs.com</strong>. We'll process your request and confirm deletion.
+            If you wish to delete your Notebook.ai account, please contact us at <strong>hello@notebook.ai</strong>. We'll process your request and confirm deletion.
           </p>
 
           <div class="bg-yellow-50 dark:bg-gray-700 border border-yellow-200 dark:border-yellow-700 rounded-lg p-4 mb-6">
@@ -257,7 +257,7 @@
             <p class="text-blue-800 dark:text-blue-200 mb-4">
               If you have questions about your account, our support team is here to help.
             </p>
-            <a href="mailto:andrew@indentlabs.com" class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors duration-200">
+            <a href="mailto:hello@notebook.ai" class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors duration-200">
               <i class="material-icons mr-2">email</i>
               Contact Support
             </a>

--- a/app/views/page_collections/rss.rss.builder
+++ b/app/views/page_collections/rss.rss.builder
@@ -9,7 +9,7 @@ xml.rss version: "2.0", "xmlns:atom": "http://www.w3.org/2005/Atom", "xmlns:cont
     xml.ttl 60
     xml.lastBuildDate @pages.first&.accepted_at&.rfc822 || Time.current.rfc822
     xml.generator "Notebook.ai Collections"
-    xml.webMaster "noreply@notebook.ai (Notebook.ai)"
+    xml.webMaster "hello@notebook.ai (Notebook.ai)"
     xml.managingEditor "#{@page_collection.user.email} (#{@page_collection.user.display_name})"
     
     # Add collection image if available

--- a/app/views/subscriptions/faq.html.erb
+++ b/app/views/subscriptions/faq.html.erb
@@ -356,7 +356,7 @@
       </summary>
       <div class="px-5 pb-5 text-gray-600 dark:text-gray-300">
         <p>
-          Please reach out to me directly at <strong>andrew@indentlabs.com</strong>.
+          Please reach out to me directly at <strong>hello@notebook.ai</strong>.
         </p>
       </div>
     </details>
@@ -418,12 +418,12 @@
   <div class="mt-12 bg-blue-50 dark:bg-gray-800 border border-blue-200 dark:border-gray-700 rounded-lg p-6">
     <h2 class="text-xl font-semibold text-gray-900 dark:text-white mb-3">Have a question that wasn't answered here?</h2>
     <p class="text-gray-600 dark:text-gray-300 mb-4">
-      Feel free to reach out any time at <strong>andrew@indentlabs.com</strong>
+      Feel free to reach out any time at <strong>hello@notebook.ai</strong>
       or post on the <%= link_to 'Site Support', 'https://www.notebook.ai/forum/site-support', class: 'text-blue-600 dark:text-blue-400 hover:underline' %>
       discussion board. I'm constantly working to make the site better and I'm always happy to help!
     </p>
     <div class="flex flex-wrap gap-3">
-      <a href="mailto:andrew@indentlabs.com" class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors duration-200">
+      <a href="mailto:hello@notebook.ai" class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors duration-200">
         <i class="material-icons mr-2">email</i>
         Email Support
       </a>

--- a/app/views/unsubscribed_mailer/unsubscribed.html.erb
+++ b/app/views/unsubscribed_mailer/unsubscribed.html.erb
@@ -17,7 +17,7 @@
     </p>
 
     <p>
-      Don’t hesitate to email any time at andrew@indentlabs.com with questions or concerns. I’m happy to help!
+      Don’t hesitate to email any time at hello@notebook.ai with questions or concerns. I’m happy to help!
     </p>
 
     <p>

--- a/app/views/unsubscribed_mailer/unsubscribed.text.erb
+++ b/app/views/unsubscribed_mailer/unsubscribed.text.erb
@@ -6,7 +6,7 @@ You can re-subscribe any time by adding a valid payment method to your account. 
 
 https://www.notebook.ai/my/billing/subscription
 
-Don’t hesitate to email any time at andrew@indentlabs.com with questions or concerns. I’m happy to help!
+Don’t hesitate to email any time at hello@notebook.ai with questions or concerns. I’m happy to help!
 
 Happy worldbuilding!
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -116,20 +116,23 @@ Rails.application.configure do
   # Devise default url options
   config.action_mailer.default_url_options = { host: 'www.notebook.ai' }
   config.active_job.default_url_options    = { host: 'www.notebook.ai' }
+
+  # Amazon SES, via its SMTP interface.
+  #
+  # SES_SMTP_USERNAME / SES_SMTP_PASSWORD are *SES SMTP credentials*, which are
+  # generated in the SES console and are NOT the same as the AWS_ACCESS_KEY_ID /
+  # AWS_SECRET_ACCESS_KEY pair used for S3 below. Generating SMTP credentials
+  # creates an IAM user with ses:SendRawEmail permission and derives an SMTP
+  # password from its secret key; the two are not interchangeable.
+  config.action_mailer.delivery_method = :smtp
   ActionMailer::Base.smtp_settings = {
-    :address        => "smtp.sendgrid.net",
+    :address        => ENV.fetch('SES_SMTP_ADDRESS', "email-smtp.#{ENV.fetch('AWS_REGION', 'us-east-1')}.amazonaws.com"),
     :port           => 587,
-    :authentication => :plain,
-    :user_name      => ENV['SENDGRID_USERNAME'],
-    :password       => ENV['SENDGRID_PASSWORD'],
-    :domain         => ENV['SENDGRID_DOMAIN'],
+    :authentication => :login,
+    :user_name      => ENV['SES_SMTP_USERNAME'],
+    :password       => ENV['SES_SMTP_PASSWORD'],
     :enable_starttls_auto => true
   }
-
-  # Settings for API key usage:
-  # authentication: :plain,
-  # user_name:      'apikey',
-  # password:       ENV['SENDGRID_API_KEY']
 
   # S3 settings for Paperclip uploads
   config.paperclip_defaults = {

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'notebook@indentlabs.com'
+  config.mailer_sender = 'Notebook.ai <hello@notebook.ai>'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/initializers/thredded.rb
+++ b/config/initializers/thredded.rb
@@ -71,7 +71,7 @@ Thredded.messageboards_order = :last_post_at_desc
 
 # ==> Email Configuration
 # Email "From:" field will use the following
-Thredded.email_from = 'notebook@indentlabs.com'
+Thredded.email_from = 'hello@notebook.ai'
 
 # Emails going out will prefix the "Subject:" with the following string
 Thredded.email_outgoing_prefix = '[Notebook.ai] '


### PR DESCRIPTION
Fixes #

Changes proposed:

- **Email Service Migration**: Replaced SendGrid SMTP configuration with Amazon SES SMTP in production environment. Updated `config/environments/production.rb` to use SES credentials (`SES_SMTP_USERNAME`, `SES_SMTP_PASSWORD`) with dynamic endpoint configuration based on AWS region.

- **Unified Support Email Address**: Consolidated all support contact email addresses from multiple addresses (`andrew@indentlabs.com`, `collaboration@notebook.ai`, `billing@notebook.ai`, `notebook@indentlabs.com`, `support@notebook.ai`, `noreply@notebook.ai`) to a single `hello@notebook.ai` address across all mailers, views, and configuration files for consistent branding and easier support management.

- **Mailer Configuration Updates**: 
  - Updated `ApplicationMailer` default from address to `Notebook.ai <hello@notebook.ai>`
  - Updated `InvoicesMailer` to use `Notebook.ai Billing <hello@notebook.ai>`
  - Removed redundant `default from` overrides in `CollaborationMailer` and `UnsubscribedMailer` to inherit from `ApplicationMailer`
  - Updated Devise mailer sender and Thredded email configuration to use the new unified address

- **Email Template Updates**: Updated all user-facing email templates and help documentation to reference `hello@notebook.ai` and improved collaboration invitation email footer to indicate replies are monitored.

@indentlabs/contributors

https://claude.ai/code/session_013ouDb5up14e1XeavAiLEDT