### PR TITLE
Improve user stats display with compact numbers and responsive layout

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -48,6 +48,20 @@ module ApplicationHelper
     user_signed_in? && current_user.notice_dismissals.where(notice_id: id).none?
   end
 
+  # Abbreviates large counts (e.g. 1190921 => "1.19M") so stat displays keep
+  # a predictable width; counts under 10,000 keep their full delimited form.
+  def compact_number(number)
+    number = number.to_i
+    return number_with_delimiter(number) if number < 10_000
+
+    number_to_human(number,
+                    format: '%n%u',
+                    precision: 3,
+                    significant: true,
+                    round_mode: :down,
+                    units: { thousand: 'K', million: 'M', billion: 'B', trillion: 'T' })
+  end
+
   # Combines and sorts gallery images from both ImageUploads and BasilCommissions
   # for consistent display across all gallery views in the application.
   # @param regular_images [Array<ImageUpload>] regular image uploads

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -110,23 +110,23 @@
           <!-- Right: Stats and Actions -->
           <div class="flex flex-col space-y-4">
             <!-- User Stats -->
-            <div class="flex items-center space-x-6">
-              <div class="text-center">
-                <div class="text-2xl font-bold text-gray-900 dark:text-gray-100"><%= number_with_delimiter @total_public_pages %></div>
-                <div class="text-sm text-gray-500 dark:text-gray-400">Pages</div>
+            <div class="flex flex-wrap items-center gap-x-6 gap-y-2 lg:justify-end">
+              <div class="text-center" title="<%= number_with_delimiter @total_public_pages %> pages">
+                <div class="text-2xl font-bold text-gray-900 dark:text-gray-100 whitespace-nowrap"><%= compact_number @total_public_pages %></div>
+                <div class="text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">Pages</div>
               </div>
-              <div class="text-center">
-                <div class="text-2xl font-bold text-blue-600 dark:text-blue-400"><%= number_with_delimiter @followers_count %></div>
-                <div class="text-sm text-gray-500 dark:text-gray-400">Followers</div>
+              <div class="text-center" title="<%= number_with_delimiter @followers_count %> followers">
+                <div class="text-2xl font-bold text-blue-600 dark:text-blue-400 whitespace-nowrap"><%= compact_number @followers_count %></div>
+                <div class="text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">Followers</div>
               </div>
-              <div class="text-center">
-                <div class="text-2xl font-bold text-green-600 dark:text-green-400"><%= number_with_delimiter @following_count %></div>
-                <div class="text-sm text-gray-500 dark:text-gray-400">Following</div>
+              <div class="text-center" title="<%= number_with_delimiter @following_count %> following">
+                <div class="text-2xl font-bold text-green-600 dark:text-green-400 whitespace-nowrap"><%= compact_number @following_count %></div>
+                <div class="text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">Following</div>
               </div>
               <% if @total_words > 0 %>
-                <div class="text-center">
-                  <div class="text-2xl font-bold text-purple-600 dark:text-purple-400"><%= number_with_delimiter @total_words %></div>
-                  <div class="text-sm text-gray-500 dark:text-gray-400">Words</div>
+                <div class="text-center" title="<%= number_with_delimiter @total_words %> words">
+                  <div class="text-2xl font-bold text-purple-600 dark:text-purple-400 whitespace-nowrap"><%= compact_number @total_words %></div>
+                  <div class="text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">Words</div>
                 </div>
               <% end %>
             </div>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -53,6 +53,18 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal 1, result[2][:data].id # regular with position 3
   end
   
+  test "compact_number abbreviates large counts and keeps small counts delimited" do
+    assert_equal '0',     compact_number(0)
+    assert_equal '168',   compact_number(168)
+    assert_equal '5,600', compact_number(5600)
+    assert_equal '9,999', compact_number(9999)
+    assert_equal '10K',   compact_number(10_000)
+    assert_equal '12.3K', compact_number(12_345)
+    assert_equal '999K',  compact_number(999_949) # rounds down, never "1000K"
+    assert_equal '1.19M', compact_number(1_190_921)
+    assert_equal '1.99B', compact_number(1_999_999_999)
+  end
+
   test "get_preview_image should prioritize pinned images" do
     # Skip test if helper method doesn't exist (for CI runs)
     skip unless respond_to?(:get_preview_image)


### PR DESCRIPTION
Fixes #

Changes proposed:

- Add `compact_number` helper method to abbreviate large counts (e.g., 1190921 => "1.19M") while keeping counts under 10,000 in delimited form for readability
- Replace `number_with_delimiter` with `compact_number` in user stats display to maintain predictable stat box widths
- Update user stats layout to be responsive with `flex-wrap` and gap utilities, with right-alignment on large screens
- Add `whitespace-nowrap` to stat values and labels to prevent text wrapping
- Add title attributes to stat containers for full count tooltips on hover
- Include comprehensive unit tests for `compact_number` covering edge cases and various magnitude ranges

@indentlabs/contributors

https://claude.ai/code/session_01YGxvAUkcrey93bQZw1faPy