### PR TITLE
Make documents in public books readable, following the universe convention

### DIFF
--- a/app/authorizers/document_authorizer.rb
+++ b/app/authorizers/document_authorizer.rb
@@ -10,6 +10,7 @@ class DocumentAuthorizer < ApplicationAuthorizer
     return true if user && user.site_administrator?
     return true if resource.privacy == 'public'
     return true if resource.universe.present? && resource.universe.privacy == 'public'
+    return true if resource.readable_via_public_book?
     return true if user && resource.universe.present? && resource.universe.contributors.pluck(:user_id).include?(user.id)
     return true if user && resource.universe.present? && resource.universe.user_id == user.id
 

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -20,6 +20,13 @@ class Book < ApplicationRecord
 
   validates :name, presence: true
 
+  # A book is effectively public when anyone can view it: either its own
+  # privacy is public, or it belongs to a public universe (which makes the
+  # book readable per BookAuthorizer).
+  def effectively_public?
+    privacy == 'public' || universe.try(:privacy) == 'public'
+  end
+
   # Track word count changes for description and blurb fields
   WORD_COUNT_TRACKED_FIELDS = %w[description blurb].freeze
 

--- a/app/models/documents/document.rb
+++ b/app/models/documents/document.rb
@@ -65,6 +65,35 @@ class Document < ApplicationRecord
 
   KEYS_TO_TRIGGER_REVISION_ON_CHANGE = %w(title body synopsis notes_text)
 
+  # Books (by the same author) that expose this document to the public:
+  # either the book itself is public, or the book is in a public universe.
+  # Scoped to the document owner's own books so another user's book can
+  # never publish this document.
+  PUBLIC_BOOK_CONDITION = <<~SQL.squish.freeze
+    books.privacy = 'public'
+    OR books.universe_id IN (SELECT universes.id FROM universes WHERE universes.privacy = 'public')
+  SQL
+
+  def containing_public_books
+    books.where(user_id: user_id).where(PUBLIC_BOOK_CONDITION)
+  end
+
+  # Mirrors the universe convention: a public container makes its contents
+  # readable. Purely additive and computed at read time, so toggling the
+  # book (or removing the document from it) instantly reverts visibility.
+  def readable_via_public_book?
+    return false if new_record?
+
+    containing_public_books.exists?
+  end
+
+  # Overrides HasPrivacy#public_content? to reflect *effective* visibility,
+  # including exposure through a public book.
+  def public_content?
+    universe_is_public = universe.present? && universe.public_content?
+    privacy == 'public' || universe_is_public || readable_via_public_book?
+  end
+
   # Archive scopes and methods (matching IsContentPage pattern)
   scope :unarchived, -> { where(archived_at: nil) }
   scope :archived, -> { where.not(archived_at: nil) }

--- a/app/views/books/_book_document_row.html.erb
+++ b/app/views/books/_book_document_row.html.erb
@@ -16,8 +16,15 @@
   <!-- Document Info -->
   <div class="flex-1 min-w-0">
     <%= link_to edit_document_path(book_document.document), class: "block group-hover:text-emerald-600 dark:group-hover:text-emerald-400" do %>
-      <h3 class="text-sm font-medium <%= Document.text_color %> line-clamp-2">
-        <%= book_document.document.title.presence || 'Untitled' %>
+      <h3 class="text-sm font-medium <%= Document.text_color %> line-clamp-2 flex items-center">
+        <span><%= book_document.document.title.presence || 'Untitled' %></span>
+        <% if book_document.book.effectively_public? && book_document.document.privacy != 'public' %>
+          <span class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200 flex-shrink-0"
+                title="This document is private, but because this book is public, anyone who can view the book can read it.">
+            <i class="material-icons text-xs mr-1">visibility</i>
+            Readable via book
+          </span>
+        <% end %>
       </h3>
       <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
         <%= number_with_delimiter(book_document.document.word_count) %> <%= 'word'.pluralize(book_document.document.word_count) %>

--- a/app/views/books/_settings_sidebar.html.erb
+++ b/app/views/books/_settings_sidebar.html.erb
@@ -144,7 +144,7 @@
               </div>
               <div class="ml-2 flex-1">
                 <div class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-0.5">Public</div>
-                <div class="text-[11px] text-gray-600 dark:text-gray-400 leading-snug">Anyone with the link can view this book.</div>
+                <div class="text-[11px] text-gray-600 dark:text-gray-400 leading-snug">Anyone with the link can view this book, including all of its chapters.</div>
               </div>
               <div x-show="selectedPrivacy === 'public'" class="text-emerald-500 flex-shrink-0 ml-1">
                 <i class="material-icons text-base">check_circle</i>
@@ -152,6 +152,21 @@
             </div>
           </div>
         </label>
+      <% end %>
+
+      <% private_chapter_count = @book.documents.where("documents.privacy IS NULL OR documents.privacy != 'public'").count %>
+      <% if private_chapter_count > 0 %>
+        <div x-show="selectedPrivacy === 'public'"
+             class="mt-3 border border-amber-300 dark:border-amber-800 rounded-lg p-3 bg-amber-50 dark:bg-amber-900 bg-opacity-100 dark:bg-opacity-30">
+          <div class="flex items-start">
+            <i class="material-icons text-amber-600 dark:text-amber-400 text-base mr-2">visibility</i>
+            <p class="text-xs text-amber-800 dark:text-amber-200 leading-snug">
+              This book contains <%= pluralize(private_chapter_count, 'private chapter') %>.
+              While the book is public, anyone who can view it can also read those chapters.
+              Making the book private again restores their privacy.
+            </p>
+          </div>
+        </div>
       <% end %>
     </div>
 

--- a/app/views/documents/_privacy_modal.html.erb
+++ b/app/views/documents/_privacy_modal.html.erb
@@ -117,6 +117,28 @@
             </div>
           <% end %>
 
+          <% exposing_books = @document.privacy == 'public' ? [] : @document.containing_public_books.to_a %>
+          <% if exposing_books.any? %>
+            <div class="mb-4 p-3 rounded-md border bg-yellow-50 dark:bg-yellow-900 border-yellow-200 dark:border-yellow-800">
+              <div class="flex items-center">
+                <div class="flex-shrink-0 mr-3">
+                  <div class="w-8 h-8 rounded-full bg-yellow-100 dark:bg-yellow-800 flex items-center justify-center">
+                    <i class="material-icons text-sm text-yellow-600 dark:text-yellow-400">warning</i>
+                  </div>
+                </div>
+                <div>
+                  <p class="text-sm font-medium text-yellow-800 dark:text-yellow-200">
+                    This document is a chapter in
+                    <%= exposing_books.map { |book| link_to("\"#{book.name}\"", book_path(book), class: 'underline') }.to_sentence.html_safe %>
+                  </p>
+                  <p class="text-xs text-yellow-600 dark:text-yellow-400">
+                    <%= exposing_books.count == 1 ? 'That book is' : 'Those books are' %> <strong>public</strong>, so anyone who can view <%= exposing_books.count == 1 ? 'it' : 'them' %> can read this document regardless of its own setting. Remove it from the book or make the book private to restore privacy.
+                  </p>
+                </div>
+              </div>
+            </div>
+          <% end %>
+
           <%= form_for(@document, remote: true, html: { id: 'document-privacy-form', data: { turbo: false } }) do |f| %>
             <div class="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg">
               <%= f.hidden_field :privacy, value: @document.privacy, id: 'document_privacy_field' %>

--- a/test/authorizers/document_authorizer_test.rb
+++ b/test/authorizers/document_authorizer_test.rb
@@ -1,0 +1,130 @@
+require 'test_helper'
+
+class DocumentAuthorizerTest < ActiveSupport::TestCase
+  setup do
+    @author   = User.first
+    @stranger = User.last
+    assert_not_equal(@author.id, @stranger.id, "Test problem: author and stranger need to be different users!")
+
+    @document = Document.create!(user: @author, title: 'Chapter One', privacy: 'private')
+  end
+
+  def anonymous
+    User.new
+  end
+
+  test "private document with no books is not readable by others" do
+    assert @author.can_read?(@document)
+    assert_not @stranger.can_read?(@document)
+    assert_not anonymous.can_read?(@document)
+  end
+
+  test "private document in a private book is not readable by others" do
+    book = Book.create!(user: @author, name: 'My Book', privacy: 'private')
+    book.book_documents.create!(document: @document)
+
+    assert_not @stranger.can_read?(@document)
+    assert_not anonymous.can_read?(@document)
+  end
+
+  test "private document in a public book is readable by anyone" do
+    book = Book.create!(user: @author, name: 'My Book', privacy: 'public')
+    book.book_documents.create!(document: @document)
+
+    assert @stranger.can_read?(@document)
+    assert anonymous.can_read?(@document)
+  end
+
+  test "private document in two books is readable when any one of them is public" do
+    private_book = Book.create!(user: @author, name: 'Private Book', privacy: 'private')
+    public_book  = Book.create!(user: @author, name: 'Public Book',  privacy: 'public')
+    private_book.book_documents.create!(document: @document)
+    public_book.book_documents.create!(document: @document)
+
+    assert @stranger.can_read?(@document)
+    assert anonymous.can_read?(@document)
+  end
+
+  test "private document in a private book within a public universe is readable by anyone" do
+    universe = Universe.create!(user: @author, name: 'Public Universe', privacy: 'public')
+    book     = Book.create!(user: @author, name: 'My Book', privacy: 'private', universe: universe)
+    book.book_documents.create!(document: @document)
+
+    assert @stranger.can_read?(@document)
+    assert anonymous.can_read?(@document)
+  end
+
+  test "removing a document from a public book restores its privacy" do
+    book = Book.create!(user: @author, name: 'My Book', privacy: 'public')
+    book_document = book.book_documents.create!(document: @document)
+    assert @stranger.can_read?(@document)
+
+    book_document.destroy
+    assert_not @stranger.can_read?(@document.reload)
+  end
+
+  test "making a public book private restores its documents' privacy" do
+    book = Book.create!(user: @author, name: 'My Book', privacy: 'public')
+    book.book_documents.create!(document: @document)
+    assert @stranger.can_read?(@document)
+
+    book.update!(privacy: 'private')
+    assert_not @stranger.can_read?(@document.reload)
+  end
+
+  test "soft-deleted public book does not expose its documents" do
+    book = Book.create!(user: @author, name: 'My Book', privacy: 'public')
+    book.book_documents.create!(document: @document)
+    assert @stranger.can_read?(@document)
+
+    book.destroy
+    assert_not @stranger.can_read?(@document.reload)
+  end
+
+  test "archived public book still exposes its documents" do
+    # Archiving is organizational: an archived public book is still viewable
+    # at its URL, so its chapters stay readable too.
+    book = Book.create!(user: @author, name: 'My Book', privacy: 'public')
+    book.book_documents.create!(document: @document)
+    book.archive!
+
+    assert @stranger.can_read?(@document)
+  end
+
+  test "another user's public book does not expose a document they don't own" do
+    book = Book.create!(user: @stranger, name: 'Not My Book', privacy: 'public')
+    # Bypasses the controller (which only allows linking your own documents)
+    # to guard against any future cross-user book membership feature.
+    BookDocument.create!(book: book, document: @document)
+
+    assert_not anonymous.can_read?(@document)
+  end
+
+  test "public book grants read access only, not update or delete" do
+    book = Book.create!(user: @author, name: 'My Book', privacy: 'public')
+    book.book_documents.create!(document: @document)
+
+    assert_not @stranger.can_update?(@document)
+    assert_not @stranger.can_delete?(@document)
+    assert @author.can_update?(@document)
+    assert @author.can_delete?(@document)
+  end
+
+  test "public_content? reflects exposure through a public book" do
+    assert_not @document.public_content?
+
+    book = Book.create!(user: @author, name: 'My Book', privacy: 'public')
+    book.book_documents.create!(document: @document)
+
+    assert @document.reload.public_content?
+    assert @document.private_content? == false
+  end
+
+  test "effectively_public? matches book readability rules" do
+    assert_not Book.create!(user: @author, name: 'Private Book', privacy: 'private').effectively_public?
+    assert Book.create!(user: @author, name: 'Public Book', privacy: 'public').effectively_public?
+
+    public_universe = Universe.create!(user: @author, name: 'Public Universe', privacy: 'public')
+    assert Book.create!(user: @author, name: 'Universe Book', privacy: 'private', universe: public_universe).effectively_public?
+  end
+end


### PR DESCRIPTION
Fixes #

Changes proposed:

 - Documents now inherit public readability from any book that contains them, mirroring the existing universe convention (a public universe makes its pages readable). Previously a public book listed all of its chapters in the public table of contents, but clicking a private chapter dead-ended in a permission error.

 - Core logic: `Book#effectively_public?` (public privacy, or in a public universe), `Document#readable_via_public_book?` (true when any same-owner book containing the document is effectively public), and a new read grant in `DocumentAuthorizer` covering `show`, `analysis`, `plaintext`, and `printable`. Read-only: update/delete are unchanged. Visibility is computed at read time — no schema changes — so making the book private again (or removing the document from it) instantly reverts. `Document#public_content?` now reflects effective visibility.

 - Safety rails: exposure is scoped to books owned by the document's author, so a future cross-user book feature can't publish someone else's private documents; soft-deleted books grant nothing; archived public books still grant (consistent with them remaining viewable at their URL).

 - Author transparency in the UI: a "Readable via book" badge on private chapters in the book editor, a warning in the book's privacy settings when publishing a book containing private chapters, and a banner in the document privacy modal linking to the public book(s) exposing the document.

 - Tests: new `test/authorizers/document_authorizer_test.rb` (13 tests) covering multi-book mixed privacy, universe transitivity, reversibility, soft-deleted/archived books, the cross-user guard, and read-only-ness.

@indentlabs/contributors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNQou3sTXxsU5cWWLrXpQR

---
_Generated by [Claude Code](https://claude.ai/code/session_01LNQou3sTXxsU5cWWLrXpQR)_