### PR TITLE
Fix N+1 image queries on universe content list pages

### DIFF
--- a/app/controllers/universes_controller.rb
+++ b/app/controllers/universes_controller.rb
@@ -33,6 +33,14 @@ class UniversesController < ContentController
 
       @content_list = @content_list.order(:name)
 
+      # Preload gallery images so preview cards don't query per-page
+      if @content_type.reflect_on_association(:image_uploads)
+        @content_list = @content_list.includes(:image_uploads)
+      end
+      if @content_type.reflect_on_association(:basil_commissions)
+        @content_list = @content_list.includes(basil_commissions: { image_attachment: :blob })
+      end
+
       render :content_list
     end
   end

--- a/app/models/concerns/has_image_uploads.rb
+++ b/app/models/concerns/has_image_uploads.rb
@@ -34,7 +34,12 @@ module HasImageUploads
     end
 
     def public_image_uploads
-      self.image_uploads.where(privacy: 'public').presence || [header_asset_for(self.class.name)]
+      uploads = if image_uploads.loaded?
+        image_uploads.select { |upload| upload.privacy == 'public' }
+      else
+        self.image_uploads.where(privacy: 'public')
+      end
+      uploads.presence || [header_asset_for(self.class.name)]
     end
 
     def private_image_uploads
@@ -55,7 +60,11 @@ module HasImageUploads
         
         # If we don't have any uploaded images, we look for saved Basil commissions
         if result.nil? && respond_to?(:basil_commissions)
-          basil_image = basil_commissions.where.not(saved_at: nil).includes([:image_attachment]).sample.try(:image)
+          basil_image = if basil_commissions.loaded?
+            basil_commissions.select { |commission| commission.saved_at.present? }.sample.try(:image)
+          else
+            basil_commissions.where.not(saved_at: nil).includes([:image_attachment]).sample.try(:image)
+          end
           # Handle Active Storage attachments properly
           if basil_image.present? && basil_image.respond_to?(:url)
             begin
@@ -101,15 +110,23 @@ module HasImageUploads
     # Returns the pinned image upload (or nil if none pinned)
     def pinned_image_upload(format = :medium)
       # First check standard image uploads
-      pinned_upload = image_uploads.pinned.first
+      pinned_upload = if image_uploads.loaded?
+        image_uploads.select(&:pinned?).min_by(&:id)
+      else
+        image_uploads.pinned.first
+      end
       if pinned_upload.present?
         url = extract_image_url(pinned_upload, format)
         return url if url.present?
       end
-      
+
       # Then check basil commissions
       if respond_to?(:basil_commissions)
-        pinned_commission = basil_commissions.pinned.where.not(saved_at: nil).includes([:image_attachment]).first
+        pinned_commission = if basil_commissions.loaded?
+          basil_commissions.select { |commission| commission.pinned? && commission.saved_at.present? }.min_by(&:id)
+        else
+          basil_commissions.pinned.where.not(saved_at: nil).includes([:image_attachment]).first
+        end
         if pinned_commission.present?
           basil_image = pinned_commission.try(:image)
           # Handle Active Storage attachments properly
@@ -128,14 +145,22 @@ module HasImageUploads
     
     # Returns the pinned public image (or nil if none pinned)
     def pinned_public_image(format = :medium)
-      pinned_upload = image_uploads.pinned.where(privacy: 'public').first
+      pinned_upload = if image_uploads.loaded?
+        image_uploads.select { |upload| upload.pinned? && upload.privacy == 'public' }.min_by(&:id)
+      else
+        image_uploads.pinned.where(privacy: 'public').first
+      end
       if pinned_upload.present?
         url = extract_image_url(pinned_upload, format)
         return url if url.present?
       end
-      
+
       if respond_to?(:basil_commissions)
-        pinned_commission = basil_commissions.pinned.where.not(saved_at: nil).includes([:image_attachment]).first
+        pinned_commission = if basil_commissions.loaded?
+          basil_commissions.select { |commission| commission.pinned? && commission.saved_at.present? }.min_by(&:id)
+        else
+          basil_commissions.pinned.where.not(saved_at: nil).includes([:image_attachment]).first
+        end
         if pinned_commission.present?
           basil_image = pinned_commission.try(:image)
           # Handle Active Storage attachments properly


### PR DESCRIPTION
Fixes NOTEBOOK-AI-TX (Sentry N+1 on `UniversesController#characters`)

Changes proposed:

 - Preload `image_uploads` and `basil_commissions` (with attached image blobs) in `UniversesController`'s dynamically-defined content-type list actions, guarded by `reflect_on_association` since the actions also serve Timeline and any future content types.

 - Teach `HasImageUploads` lookup methods (`public_image_uploads`, `pinned_public_image`, `pinned_image_upload`, and the basil branch of `random_image_including_private`) to filter the in-memory association when it's already loaded, falling back to the original scoped queries otherwise. Preloading alone wouldn't help because these methods build fresh scopes that bypass the loaded association. In-memory filters mirror the SQL semantics: `min_by(&:id)` matches `.first`'s implicit `ORDER BY id ASC LIMIT 1`, and acts_as_paranoid's `deleted_at IS NULL` default scope applies to preloads too.

 - Net effect: `/plan/universes/:id/characters` on a ~100-character universe drops from ~300 image-lookup queries (three per wiki card via `custom_public_thumbnail_url`) to ~5 total. Behavior on non-preloaded call sites (show pages, profiles, etc.) is unchanged.

@indentlabs/contributors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Lndxf5pPM2XHWREkGv2jU

---
_Generated by [Claude Code](https://claude.ai/code/session_018Lndxf5pPM2XHWREkGv2jU)_