### PR TITLE
Fix timeline editor tag persistence and event reordering

### DIFF
--- a/app/assets/javascripts/timeline-editor.js
+++ b/app/assets/javascripts/timeline-editor.js
@@ -57,12 +57,20 @@ function persistTimelineOrder() {
   if (!eventsContainer) return Promise.resolve();
 
   const timelineId = eventsContainer.dataset.timelineId;
-  const orderedIds = Array.from(eventsContainer.children)
-    .filter(el =>
-      el.classList.contains('timeline-event-container') &&
-      !el.classList.contains('timeline-event-template'))
+  // The event cards are nested inside a wrapper div (the one carrying the
+  // timeline spine), not direct children of the container, so query descendants.
+  // querySelectorAll returns them in document order, which is the visual order.
+  const orderedIds = Array.from(
+      eventsContainer.querySelectorAll('.timeline-event-container:not(.timeline-event-template)'))
     .map(el => el.dataset.eventId)
     .filter(id => id && id !== '-1');
+
+  // Never send an empty list: the server would have nothing to apply and the
+  // move would silently not persist. If we found no cards, something about the
+  // DOM is wrong — fail loudly so the UI shows an error instead of "saved".
+  if (orderedIds.length === 0) {
+    return Promise.reject(new Error('No timeline events found to reorder'));
+  }
 
   return enqueueTimelineReorder(function() {
     return fetch('/internal/reorder/timeline_events', {
@@ -612,8 +620,11 @@ document.addEventListener('DOMContentLoaded', function() {
       emptyState.style.display = 'none';
     }
 
-    // Insert the server-rendered HTML
-    eventsContainer.insertAdjacentHTML('beforeend', html);
+    // Insert the server-rendered HTML inside the events wrapper (the div that
+    // carries the timeline spine) so the new card sits alongside the other
+    // event cards; fall back to the container when the timeline was empty.
+    const eventsList = eventsContainer.querySelector('.timeline-events-list') || eventsContainer;
+    eventsList.insertAdjacentHTML('beforeend', html);
 
     // Get reference to the newly added event
     const newEvent = eventsContainer.querySelector(`[data-event-id="${eventId}"]`);

--- a/app/assets/javascripts/timeline_editor_component.js
+++ b/app/assets/javascripts/timeline_editor_component.js
@@ -407,13 +407,19 @@ function timelineEditor() {
         this.updateSidebarLinkedContent(eventId);
       });
 
-      if (eventData && eventData.tags) {
-        this.eventTags[eventId] = eventData.tags;
-        if (eventData.tags.length > 0) {
-          this.updateMainPanelTags(eventId);
+      // eventData.tags comes from the @click handler baked into the card's HTML
+      // at page-render time, so it goes stale as soon as tags change in this
+      // session. Only use it to seed an empty cache — never to overwrite live
+      // state, which made freshly added tags vanish on re-click.
+      if (!this.eventTags[eventId]) {
+        if (eventData && eventData.tags) {
+          this.eventTags[eventId] = eventData.tags;
+          if (eventData.tags.length > 0) {
+            this.updateMainPanelTags(eventId);
+          }
+        } else {
+          this.getEventTags(eventId);
         }
-      } else {
-        this.getEventTags(eventId);
       }
 
       const inspectorContent = document.querySelector('.w-96 .overflow-y-auto');

--- a/app/controllers/timeline_events_controller.rb
+++ b/app/controllers/timeline_events_controller.rb
@@ -143,6 +143,13 @@ class TimelineEventsController < ApplicationController
     return render json: { error: 'Timeline not found' }, status: :not_found unless timeline
 
     ordered_ids = Array(params[:ordered_ids]).map(&:to_i)
+    # An empty list means the client failed to read the event cards from the
+    # DOM (or sent a malformed request). Applying it would be a silent no-op
+    # that the client reports as "saved", so reject it loudly instead.
+    if ordered_ids.empty?
+      return render json: { status: 'error', message: 'No event ids provided' }, status: :unprocessable_entity
+    end
+
     events_by_id = timeline.timeline_events.index_by(&:id)
 
     position = 0
@@ -177,13 +184,20 @@ class TimelineEventsController < ApplicationController
     tag_name = params[:tag_name]&.strip
     return render json: { error: 'Tag name is required' }, status: :bad_request if tag_name.blank?
     
-    # Check if tag already exists for this event
+    # Adding a tag that's already on the event is a no-op, not an error: the
+    # editor adds tags optimistically and rolls the tag back out of the UI when
+    # the server reports failure, so treating a duplicate as an error made
+    # re-adding an existing tag look like tags weren't saving at all.
     existing_tag = @timeline_event.page_tags.find_by(tag: tag_name)
     if existing_tag
-      return render json: { 
-        status: 'error', 
-        message: 'Tag already exists for this event' 
-      }, status: :unprocessable_entity
+      return render json: {
+        status: 'success',
+        message: 'Tag already exists for this event',
+        tag: {
+          id: existing_tag.id,
+          name: existing_tag.tag
+        }
+      }
     end
     
     # Create the tag

--- a/app/views/timelines/edit.html.erb
+++ b/app/views/timelines/edit.html.erb
@@ -225,7 +225,7 @@
 
           <!-- Timeline Events Section with Spine -->
           <% if @timeline.timeline_events.any? %>
-            <div class="relative">
+            <div class="relative timeline-events-list">
               <!-- Timeline Rail - Only for events -->
               <div class="absolute top-0 bottom-0 w-0.5 bg-gray-300 dark:bg-gray-700 timeline-spine rounded-full" style="left: 38px;"></div>
 
@@ -851,16 +851,21 @@ function timelineEditor() {
         this.updateSidebarLinkedContent(eventId);
       });
 
-      // Load tags for this event - use provided tags or ensure they're cached
-      if (eventData && eventData.tags) {
-        this.eventTags[eventId] = eventData.tags;
-        // Only update tag display if tags were actually provided
-        if (eventData.tags.length > 0) {
-          this.updateMainPanelTags(eventId);
+      // Load tags for this event. eventData.tags comes from the @click handler
+      // baked into the card's HTML at page-render time, so it goes stale as soon
+      // as tags are added or removed in this session. Only use it to seed an
+      // empty cache — never to overwrite live state, which made freshly added
+      // tags vanish whenever an event card was re-clicked.
+      if (!this.eventTags[eventId]) {
+        if (eventData && eventData.tags) {
+          this.eventTags[eventId] = eventData.tags;
+          if (eventData.tags.length > 0) {
+            this.updateMainPanelTags(eventId);
+          }
+        } else {
+          // getEventTags() will handle caching from DOM if needed
+          this.getEventTags(eventId);
         }
-      } else {
-        // getEventTags() will handle caching from DOM if needed
-        this.getEventTags(eventId);
       }
 
       // Scroll inspector panel to top

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -392,7 +392,9 @@ Rails.application.routes.draw do
       post 'link',              to: 'timeline_events#link_entity',    on: :member
       post 'unlink/:entity_id', to: 'timeline_events#unlink_entity',  on: :member, as: :unlink_entity
       post 'tags',              to: 'timeline_events#add_tag',        on: :member, as: :add_tag
-      delete 'tags/:tag_name',  to: 'timeline_events#remove_tag',     on: :member, as: :remove_tag
+      # tag_name may contain dots (e.g. "v1.0"); without the constraint the
+      # router would treat everything after the last dot as a format extension.
+      delete 'tags/:tag_name',  to: 'timeline_events#remove_tag',     on: :member, as: :remove_tag, constraints: { tag_name: /[^\/]+/ }
     end
 
     # Content attributes

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -83,6 +83,8 @@ if (sassLoaderConfig) {
 // Remove Webpacker's CSS minifier entirely.
 // cssnano v4 (bundled) recursively removes spaces in empty variables (like `--tw-gradient-from-position: ;` -> `tw-gradient-from-position:;`)
 // which causes modern CSS engines to invalidate the entire declaration, breaking Tailwind v3 gradients completely.
-environment.plugins.delete('OptimizeCSSAssets')
+// The plugin is only registered for production builds; deleting a missing item
+// throws and breaks development/test compilation, so tolerate its absence.
+try { environment.plugins.delete('OptimizeCSSAssets') } catch (e) {}
 
 module.exports = environment

--- a/test/controllers/timeline_editor_render_test.rb
+++ b/test/controllers/timeline_editor_render_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+# Regression coverage for "changes made in the timeline editor disappear on
+# refresh": whatever the tag/reorder endpoints persist must actually be
+# rendered back by the edit page.
+class TimelineEditorRenderTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @owner = users(:one)
+    @timeline = Timeline.create!(name: "Render Test Timeline", user: @owner)
+    @event = @timeline.timeline_events.first
+    sign_in @owner
+  end
+
+  test "tags added through the endpoint are rendered on the edit page" do
+    post add_tag_timeline_event_path(@event), params: { tag_name: "Foreshadowing" }, as: :json
+    assert_response :success
+
+    get edit_timeline_path(@timeline)
+    assert_response :success
+    assert_includes response.body, "Foreshadowing"
+    assert_select "#event-tags-#{@event.id} span", text: /Foreshadowing/
+  end
+
+  test "event order persisted through the reorder endpoint is rendered on the edit page" do
+    2.times { |i| @timeline.timeline_events.create!(title: "Event #{i}") }
+    ids = @timeline.timeline_events.reload.map(&:id)
+    desired = ids.reverse
+
+    patch reorder_timeline_events_internal_path,
+          params: { timeline_id: @timeline.id, ordered_ids: desired },
+          as: :json
+    assert_response :success
+
+    get edit_timeline_path(@timeline)
+    assert_response :success
+
+    rendered_order = response.body.scan(/data-event-id="(\d+)"/).flatten.map(&:to_i).uniq
+    assert_equal desired, rendered_order & desired,
+                 "Edit page should render events in their persisted order"
+  end
+end

--- a/test/controllers/timeline_event_tags_test.rb
+++ b/test/controllers/timeline_event_tags_test.rb
@@ -1,0 +1,85 @@
+require 'test_helper'
+
+# Covers the tag endpoints on TimelineEventsController (add_tag / remove_tag),
+# which the timeline editor's inspector panel uses to tag individual events.
+class TimelineEventTagsTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @owner = users(:one)
+    @other = users(:two)
+
+    @timeline = Timeline.create!(name: "Test Timeline", user: @owner)
+    @event = @timeline.timeline_events.first
+  end
+
+  def add_tag(tag_name)
+    post add_tag_timeline_event_path(@event),
+         params: { tag_name: tag_name },
+         as: :json
+  end
+
+  def remove_tag(tag_name)
+    delete remove_tag_timeline_event_path(@event, tag_name: tag_name)
+  end
+
+  test "owner can add a tag and it persists" do
+    sign_in @owner
+
+    add_tag("Foreshadowing")
+
+    assert_response :success
+    assert_equal ["Foreshadowing"], @event.reload.page_tags.pluck(:tag)
+  end
+
+  test "adding a duplicate tag is an idempotent success, not an error" do
+    # The editor adds tags optimistically and removes them from the UI when the
+    # server reports failure, so a duplicate must not be treated as an error.
+    sign_in @owner
+    @event.page_tags.create!(tag: "Foreshadowing", slug: "foreshadowing", user: @owner)
+
+    add_tag("Foreshadowing")
+
+    assert_response :success
+    assert_equal 1, @event.reload.page_tags.count
+  end
+
+  test "owner can remove a tag" do
+    sign_in @owner
+    @event.page_tags.create!(tag: "Foreshadowing", slug: "foreshadowing", user: @owner)
+
+    remove_tag("Foreshadowing")
+
+    assert_response :success
+    assert_empty @event.reload.page_tags
+  end
+
+  test "tags with spaces survive the URL round-trip on removal" do
+    sign_in @owner
+    @event.page_tags.create!(tag: "Character Development", slug: "character-development", user: @owner)
+
+    delete remove_tag_timeline_event_path(@event, tag_name: "Character Development")
+
+    assert_response :success
+    assert_empty @event.reload.page_tags
+  end
+
+  test "tags containing a period survive the URL round-trip on removal" do
+    sign_in @owner
+    @event.page_tags.create!(tag: "v1.0", slug: "v10", user: @owner)
+
+    delete remove_tag_timeline_event_path(@event, tag_name: "v1.0")
+
+    assert_response :success
+    assert_empty @event.reload.page_tags
+  end
+
+  test "non-owner cannot add a tag" do
+    sign_in @other
+
+    add_tag("Sabotage")
+
+    assert_response :forbidden
+    assert_empty @event.reload.page_tags
+  end
+end

--- a/test/controllers/timeline_events_reorder_test.rb
+++ b/test/controllers/timeline_events_reorder_test.rb
@@ -78,6 +78,17 @@ class TimelineEventsReorderTest < ActionDispatch::IntegrationTest
     assert_equal (@event_ids - [moved]), result[1..], "Omitted events keep their relative order"
   end
 
+  test "rejects an empty ordered_ids payload instead of silently no-opping" do
+    # A client bug that fails to read the event cards from the DOM sends an
+    # empty list; that must be an error, not a fake "position saved" success.
+    sign_in @owner
+
+    reorder([])
+
+    assert_response :unprocessable_entity
+    assert_equal @event_ids, ordered_event_ids, "Order must be unchanged"
+  end
+
   test "rejects reordering a timeline the user does not own" do
     sign_in @other
     original = ordered_event_ids


### PR DESCRIPTION
Fixes #

Changes proposed:

- **Fix stale tag cache on event re-click**: Modified the tag loading logic to only seed the event tags cache from page-render data when the cache is empty. This prevents freshly added tags from vanishing when an event card is clicked again, since the baked-in HTML data becomes stale as soon as tags change in the current session.

- **Validate non-empty event IDs in reorder endpoint**: Added validation to reject empty `ordered_ids` payloads with a 422 error instead of silently no-opping. This prevents client bugs that fail to read event cards from the DOM from appearing as successful saves.

- **Fix event card insertion for non-empty timelines**: Updated the new event card insertion logic to target the `.timeline-events-list` wrapper (which carries the timeline spine) instead of the container, ensuring new cards are placed alongside existing events rather than outside the spine structure.

- **Handle tag names with special characters in routes**: Added a route constraint `{ tag_name: /[^\/]+/ }` to the remove_tag endpoint to prevent the router from treating dots in tag names (e.g., "v1.0") as format extensions.

- **Improve webpack CSS minifier handling**: Wrapped the OptimizeCSSAssets plugin deletion in a try-catch to tolerate its absence in development/test builds, preventing compilation failures.

- **Add comprehensive test coverage**: Created two new test suites:
  - `TimelineEventTagsTest`: Covers tag add/remove endpoints, idempotent duplicate handling, special character handling, and authorization
  - `TimelineEditorRenderTest`: Regression tests ensuring persisted changes (tags and event order) are actually rendered on page refresh

@indentlabs/contributors

https://claude.ai/code/session_014QPCGrSExACzmeyqGTH2CL