### PR TITLE
Fix 500 when a page update carries a file we don't accept as an image

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -521,14 +521,14 @@ class ContentController < ApplicationController
   end
 
   def upload_files image_uploads_list, content_type, content_id
+    upload_errors = []
+    out_of_bandwidth = false
+
     image_uploads_list.each do |image_data|
       image_size_kb = File.size(image_data.tempfile.path) / 1000.0
 
       if current_user.upload_bandwidth_kb < image_size_kb
-        flash[:alert] = [
-          "At least one of your images failed to upload because you do not have enough upload bandwidth.",
-          "<a href='#{subscription_path}' class='btn white black-text center-align'>Get more</a>"
-        ].map { |p| "<p>#{p}</p>" }.join
+        out_of_bandwidth = true
         next
       else
         current_user.update(upload_bandwidth_kb: current_user.upload_bandwidth_kb - image_size_kb)
@@ -541,7 +541,23 @@ class ContentController < ApplicationController
         src: image_data,
         privacy: 'public'
       )
+
+      next if related_image.persisted?
+
+      # Nothing was stored, so hand the bandwidth we just charged back over.
+      current_user.update(upload_bandwidth_kb: current_user.upload_bandwidth_kb + image_size_kb)
+
+      filename = ERB::Util.html_escape(image_data.original_filename.presence || 'Your image')
+      reason   = related_image.errors[:src].first.presence || "couldn't be uploaded"
+      upload_errors << "#{filename} #{reason}."
     end
+
+    if out_of_bandwidth
+      upload_errors << "At least one of your images failed to upload because you do not have enough upload bandwidth."
+      upload_errors << "<a href='#{subscription_path}' class='btn white black-text center-align'>Get more</a>"
+    end
+
+    flash[:alert] = upload_errors.map { |p| "<p>#{p}</p>" }.join if upload_errors.any?
   end
 
   def destroy

--- a/app/models/page_data/image_upload.rb
+++ b/app/models/page_data/image_upload.rb
@@ -33,7 +33,9 @@ class ImageUpload < ApplicationRecord
     s3_protocol: 'https'
   # has_one_attached :upload
 
-  validates_attachment_content_type :src, content_type: /\Aimage\/.*\Z/
+  validates_attachment_content_type :src,
+    content_type: /\Aimage\/.*\Z/,
+    message: "must be an image file (like a jpg, png, gif, or webp)"
   # TODO add size validation
 
   before_destroy :delete_s3_image

--- a/config/initializers/paperclip_ruby3_compat.rb
+++ b/config/initializers/paperclip_ruby3_compat.rb
@@ -1,0 +1,63 @@
+# Paperclip 6.1.0 is unmaintained and predates Ruby 3's separation of positional
+# and keyword arguments. Its validators build an options Hash and pass it as a
+# third *positional* argument to ActiveModel::Errors#add:
+#
+#   record.errors.add attribute, :invalid, options.merge(:types => types.join(', '))
+#
+# Rails 6.1 defines `add(attribute, type = :invalid, **options)`, so under Ruby 3
+# that Hash is no longer auto-converted to keyword arguments and every attempt to
+# record a validation failure raises:
+#
+#   ArgumentError: wrong number of arguments (given 3, expected 1..2)
+#
+# In practice that turned "user uploaded a file we don't accept" into an
+# unhandled 500 on every content page update carrying an image.
+#
+# These patches re-issue the same calls with a double splat. Delete them along
+# with paperclip once ImageUpload has finished migrating to ActiveStorage.
+
+Paperclip::Validators::AttachmentContentTypeValidator.class_eval do
+  def mark_invalid(record, attribute, types)
+    record.errors.add attribute, :invalid, **options.symbolize_keys.merge(types: types.join(', '))
+  end
+end
+
+Paperclip::Validators::AttachmentFileNameValidator.class_eval do
+  def mark_invalid(record, attribute, patterns)
+    record.errors.add attribute, :invalid, **options.symbolize_keys.merge(names: patterns.join(', '))
+  end
+end
+
+Paperclip::Validators::AttachmentPresenceValidator.class_eval do
+  def validate_each(record, attribute, value)
+    if record.send("#{attribute}_file_name").blank?
+      record.errors.add(attribute, :blank, **options.symbolize_keys)
+    end
+  end
+end
+
+Paperclip::Validators::AttachmentSizeValidator.class_eval do
+  def validate_each(record, attr_name, value)
+    base_attr_name = attr_name
+    attr_name = "#{attr_name}_file_size".to_sym
+    value = record.send(:read_attribute_for_validation, attr_name)
+
+    return if value.blank?
+
+    options.slice(*self.class::AVAILABLE_CHECKS).each do |option, option_value|
+      option_value = option_value.call(record) if option_value.is_a?(Proc)
+      option_value = extract_option_value(option, option_value)
+
+      next if value.send(self.class::CHECKS[option], option_value)
+
+      error_message_key = options[:in] ? :in_between : option
+      [attr_name, base_attr_name].each do |error_attr_name|
+        record.errors.add(error_attr_name, error_message_key, **filtered_options(value).symbolize_keys.merge(
+          min: min_value_in_human_size(record),
+          max: max_value_in_human_size(record),
+          count: human_size(option_value)
+        ))
+      end
+    end
+  end
+end

--- a/test/models/image_upload_content_type_test.rb
+++ b/test/models/image_upload_content_type_test.rb
@@ -1,0 +1,67 @@
+require 'test_helper'
+
+class ImageUploadContentTypeTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:one)
+    @character = characters(:one)
+  end
+
+  def upload_for(path, content_type)
+    ImageUpload.new(
+      user: @user,
+      content_type: 'Character',
+      content_id: @character.id,
+      privacy: 'public',
+      src: Rack::Test::UploadedFile.new(path, content_type)
+    )
+  end
+
+  # Paperclip 6.1 hands its options hash to ActiveModel::Errors#add positionally,
+  # which Ruby 3 no longer converts to keyword arguments. Before we patched the
+  # validators (config/initializers/paperclip_ruby3_compat.rb), *recording* this
+  # rejection raised ArgumentError, so uploading a non-image 500'd the whole page
+  # update rather than failing the one attachment.
+  test "rejecting a non-image records a validation error instead of raising" do
+    Tempfile.create(['not-an-image', '.pdf']) do |file|
+      file.write('%PDF-1.4 definitely not an image')
+      file.rewind
+
+      upload = upload_for(file.path, 'application/pdf')
+
+      assert_nothing_raised { upload.valid? }
+      assert_not upload.valid?, "A PDF should not pass the image content type validation"
+      assert_includes upload.errors[:src].join(' '), 'must be an image file'
+    end
+  end
+
+  # ContentController#upload_files reads errors[:src] to tell the user which file
+  # was turned away and why, so the message has to land on that attribute.
+  test "the rejection message is readable enough to show the uploader" do
+    Tempfile.create(['not-an-image', '.pdf']) do |file|
+      file.write('%PDF-1.4 definitely not an image')
+      file.rewind
+
+      upload = upload_for(file.path, 'application/pdf')
+      upload.valid?
+
+      assert_equal "must be an image file (like a jpg, png, gif, or webp)", upload.errors[:src].first
+    end
+  end
+
+  test "an image still passes the content type validation" do
+    # Style generation would shell out to ImageMagick, which this test doesn't
+    # need — only the content type check is under test here.
+    original = Paperclip::Attachment.default_options[:post_processing]
+    Paperclip::Attachment.default_options[:post_processing] = false
+
+    # A 1x1 transparent GIF.
+    Tempfile.create(['an-image', '.gif'], binmode: true) do |file|
+      file.write(Base64.decode64('R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'))
+      file.rewind
+
+      assert upload_for(file.path, 'image/gif').valid?, "A GIF should pass the image content type validation"
+    end
+  ensure
+    Paperclip::Attachment.default_options[:post_processing] = original
+  end
+end


### PR DESCRIPTION
Fixes # (Sentry NOTEBOOK-AI-F — `ArgumentError: wrong number of arguments (given 3, expected 1..2)` in `CharactersController#update`)

Paperclip 6.1 hands its options hash to `ActiveModel::Errors#add` as a third *positional* argument:

```ruby
record.errors.add attribute, :invalid, options.merge(:types => types.join(', '))
```

Rails 6.1 declares that method as `add(attribute, type = :invalid, **options)`, and Ruby 3 no longer converts a trailing positional hash into keyword arguments — so *recording* a rejected attachment raised instead of failing validation.

The blast radius is bigger than a mangled message. Paperclip runs the content type validator before processing precisely so `post_process_styles` can be skipped for files it won't accept (`check_validity_before_processing`, on by default). That design depends on `errors.add` working, so the exception escaped during attribute assignment inside `ImageUpload.create` — and `ContentController#update` calls `upload_files` before it touches the page at all. One unsupported file took down the entire PATCH.

Changes proposed:

 - Patch the four Paperclip validators that make this call to splat their options (`config/initializers/paperclip_ruby3_compat.rb`). Only the content type one is wired up today, but they share the bug verbatim and `image_upload.rb` already carries a `TODO add size validation` that would walk straight into it.

 - Tell the uploader which file was turned away and why. With errors recorded rather than raised, a rejected upload was otherwise silently dropped, and the user had already been charged bandwidth for an image that never got stored — so refund that too.

 - Add a regression test. With the initializer removed it errors with the exact production message, raised from `ImageUpload.new`, confirming the before-processing path from the stack trace.

The patch is deliberately scoped to Paperclip rather than `ActiveModel::Errors#add` itself. Patching Rails would fix every stale gem at once with less code, but it changes a core API app-wide and would quietly survive a Rails upgrade. This version lives in a paperclip-named file that gets deleted along with the gem when `ImageUpload` finishes migrating to ActiveStorage.

### Testing

`test/models` and `test/unit` pass apart from 1 failure + 3 errors in `DocumentTest`, and `test/controllers` reports 226 `ActionView::Template::Error`s from a missing Webpacker manifest (CI precompiles assets first; my sandbox didn't). Both are pre-existing — I confirmed by stashing the change and re-running, and the controller baseline is identical at 275 tests / 0 failures / 226 errors / 1 skip.

@indentlabs/contributors


---
_Generated by [Claude Code](https://claude.ai/code/session_016G8d5rxYXYuesrDiuNxXvv)_