### PR TITLE
Fix document headers rendering as normal text

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@rails/ujs": "^7.1.3-4",
     "@rails/webpacker": "^5.2.1",
     "@tailwindcss/forms": "^0.5.0",
+    "@tailwindcss/typography": "^0.5.20",
     "@types/react": "^17.0.13",
     "autoprefixer": "^10",
     "axios": "^0.21.2",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -104,6 +104,7 @@ module.exports = {
   },
   plugins: [
     require('@tailwindcss/forms'),
+    require('@tailwindcss/typography'),
     function({ addUtilities }) {
       addUtilities({
         '.text-shadow': {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1288,6 +1288,13 @@
   dependencies:
     mini-svg-data-uri "^1.2.3"
 
+"@tailwindcss/typography@^0.5.20":
+  version "0.5.20"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.20.tgz#9feb7fb1d5f2f7b5360c22e24651210db74c34df"
+  integrity sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==
+  dependencies:
+    postcss-selector-parser "6.0.10"
+
 "@types/glob@^7.1.1":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
@@ -6398,6 +6405,14 @@ postcss-selector-not@^4.0.0:
   dependencies:
     balanced-match "^1.0.0"
     postcss "^7.0.2"
+
+postcss-selector-parser@6.0.10:
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz#79b61e2c0d1bfc2602d549e11d0876256f8df88d"
+  integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
 
 postcss-selector-parser@^3.0.0:
   version "3.1.2"


### PR DESCRIPTION
Fixes #

Changes proposed:

 - Install `@tailwindcss/typography` (v0.5.20) and register it in `tailwind.config.js`, so the `prose`, `prose-lg`, `prose-headings:*`, and `dark:prose-invert` classes already used across ~32 views actually generate CSS
 - This fixes the reported bug where applying any of the editor's three header options left the text looking completely unchanged: the `<h2>/<h3>/<h4>` tags were applied correctly, but with the plugin missing, Tailwind's preflight reset collapsed every heading to paragraph size/weight on the document reading view (verified: an `<h2>` computed to 16px / weight 400, identical to a `<p>`; after this change it renders 36px / bold)
 - CSS bundle impact is negligible: +35 KB minified / +3.9 KB gzipped, no JS or runtime changes

Known follow-ups surfaced during review (not included in this PR):

 - `app/javascript/application.css` imports Tailwind layers as base → utilities → components; the plugin's `.prose` component rules therefore land after utilities and override `max-w-none` / `text-gray-900` on prose containers. Should be reordered to base → components → utilities.
 - Legacy hand-rolled `.prose` margin rules in `timeline_viewer.scss` and `document_editor.scss` (specificity 0,1,1) still override the plugin's `:where()`-based spacing site-wide, e.g. `.prose h1-h6 { margin-top: 0 }`.
 - The editor still styles headings via legacy `#editor h2/h3/h4` rules in `editor.scss`, so editor and reading view render headings slightly differently.

@indentlabs/contributors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4YsrszSBT4ReLYDx3arEu

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4YsrszSBT4ReLYDx3arEu)_