### PR TITLE
Keep page sidebars from sliding under the site nav rail on tablet widths

### DIFF
--- a/app/views/content/edit.html.erb
+++ b/app/views/content/edit.html.erb
@@ -64,7 +64,7 @@
            x-transition:enter-end="translate-x-0"
            x-transition:leave="transform transition ease-in-out duration-200"
            x-transition:leave-end="-translate-x-full"
-           class="lg:hidden fixed left-0 top-0 h-full w-72 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 shadow-xl z-50 overflow-y-auto">
+           class="lg:hidden fixed left-0 site-nav-offset-left top-0 h-full w-72 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 shadow-xl z-50 overflow-y-auto">
 
         <!-- Mobile Close button -->
         <div class="p-3 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 lg:hidden">
@@ -96,7 +96,7 @@
       </div>
 
       <!-- Mobile/Tablet Left Sidebar Toggle Tab -->
-      <div class="lg:hidden fixed top-28 z-30 transition-all duration-300">
+      <div class="lg:hidden fixed left-0 site-nav-offset-left top-28 z-30 transition-all duration-300">
         <button @click="toggleLeftSidebar()"
                 @keydown.escape="showLeftSidebar && toggleLeftSidebar()"
                 class="bg-notebook-blue hover:bg-blue-600 text-white p-2 rounded-r-md shadow-lg transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 flex items-center gap-1"

--- a/app/views/content/show.html.erb
+++ b/app/views/content/show.html.erb
@@ -37,7 +37,7 @@
       </div>
 
       <!-- Mobile/Tablet Left Sidebar Toggle Tab -->
-      <div class="lg:hidden fixed left-0 top-28 z-40">
+      <div class="lg:hidden fixed left-0 site-nav-offset-left top-28 z-40">
         <button @click="showLeftSidebar = !showLeftSidebar"
                 class="bg-notebook-blue hover:bg-blue-600 text-white p-2 rounded-r-md shadow-lg transition-all duration-300 flex items-center gap-1"
                 title="Navigation">
@@ -67,7 +67,7 @@
            x-transition:leave="transform transition ease-in-out duration-200"
            x-transition:leave-start="translate-x-0"
            x-transition:leave-end="-translate-x-full"
-           class="lg:hidden fixed left-0 top-0 h-full w-72 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 shadow-xl z-50 overflow-y-auto">
+           class="lg:hidden fixed left-0 site-nav-offset-left top-0 h-full w-72 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 shadow-xl z-50 overflow-y-auto">
 
         <!-- Close button -->
         <div class="p-4 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -172,7 +172,7 @@
          x-transition:leave="transform transition ease-in-out duration-200"
          x-transition:leave-start="translate-x-0"
          x-transition:leave-end="-translate-x-full"
-         class="lg:hidden fixed left-0 top-0 h-full w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 shadow-xl z-50 overflow-y-auto styled-scrollbar">
+         class="lg:hidden fixed left-0 site-nav-offset-left top-0 h-full w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 shadow-xl z-50 overflow-y-auto styled-scrollbar">
       
       <!-- Sidebar Header -->
       <div class="p-3 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
@@ -296,7 +296,7 @@
     </div>
 
     <!-- Mobile/Tablet Left Sidebar Toggle Tab -->
-    <div class="lg:hidden fixed z-30"
+    <div class="lg:hidden fixed left-0 site-nav-offset-left z-30"
          style="top: 132px;">
       <button @click="toggleLeftSidebar()"
               @keydown.escape="showLeftSidebar && toggleLeftSidebar()"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,11 +59,33 @@
     [data-sidebar-initial] header {
       transition: none !important;
     }
+
+    /*
+      Page-level off-canvas sidebars (table of contents, quick access, etc.) and
+      their toggle tabs are positioned against the viewport, so without an offset
+      they slide underneath the fixed site navigation rail.
+
+      Only tablet widths need the offset: below 768px the site nav is off-canvas,
+      and from 1024px up those page sidebars are laid out in-flow instead.
+    */
+    @media (min-width: 768px) and (max-width: 1023px) {
+      /* Before Alpine boots, the rail is sized by the [data-sidebar-initial] rules above */
+      [data-sidebar-initial="collapsed"] .site-nav-offset-left { left: 4rem; }
+      [data-sidebar-initial="open"] .site-nav-offset-left { left: 14rem; }
+
+      /* Once Alpine owns the rail, its expanded width comes from `sm:w-60` at this breakpoint */
+      body.site-nav-collapsed .site-nav-offset-left { left: 4rem; }
+      body.site-nav-open .site-nav-offset-left { left: 15rem; }
+    }
   </style>
 </head>
 <body data-in-app="true"
       class="<%= controller_name %> <%= action_name %> <%= 'dark' if user_signed_in? && current_user.dark_mode_enabled? %>"
-      :class="{ 'overflow-hidden': showSidebar && !isDesktop }"
+      :class="{
+        'overflow-hidden': showSidebar && !isDesktop<% if user_signed_in? %>,
+        'site-nav-open': showSidebar && isDesktop,
+        'site-nav-collapsed': !showSidebar && isDesktop<% end %>
+      }"
       x-data="{
         isDesktop: window.innerWidth >= 768,
         showSidebar: (() => {

--- a/app/views/timelines/edit.html.erb
+++ b/app/views/timelines/edit.html.erb
@@ -46,7 +46,7 @@
          x-transition:enter-end="translate-x-0"
          x-transition:leave="transform transition ease-in-out duration-200"
          x-transition:leave-end="-translate-x-full"
-         class="lg:hidden fixed left-0 top-0 h-full w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 shadow-xl z-50 overflow-y-auto">
+         class="lg:hidden fixed left-0 site-nav-offset-left top-0 h-full w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 shadow-xl z-50 overflow-y-auto">
 
       <%# Mobile close button - dynamic based on active panel %>
       <div class="p-3 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 lg:hidden">
@@ -103,7 +103,7 @@
     </div>
 
     <%# Mobile/Tablet Search / Filter Toggle Tab %>
-    <div class="lg:hidden fixed left-0 top-28 z-30">
+    <div class="lg:hidden fixed left-0 site-nav-offset-left top-28 z-30">
       <button @click="toggleLeftPanel('filter')"
               class="text-white p-2 rounded-r-md shadow-lg transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 flex items-center gap-1"
               :class="activeLeftPanel === 'filter' ? '<%= Timeline.color %>' : 'bg-notebook-blue hover:bg-blue-600'"
@@ -115,7 +115,7 @@
     </div>
 
     <%# Mobile/Tablet Linked Content Toggle Tab %>
-    <div class="lg:hidden fixed left-0 top-40 z-30">
+    <div class="lg:hidden fixed left-0 site-nav-offset-left top-40 z-30">
       <button @click="toggleLeftPanel('linked-content')"
               class="text-white p-2 rounded-r-md shadow-lg transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 flex items-center gap-1"
               :class="activeLeftPanel === 'linked-content' ? '<%= Timeline.color %>' : 'bg-notebook-blue hover:bg-blue-600'"


### PR DESCRIPTION
## User-facing changes

 - On tablet-sized screens, opening a page's left sidebar (a page's table of contents, the timeline editor's filter and linked-content panels, the document list's quick access panel) no longer slides it underneath the site navigation rail, so its headings and links are fully readable instead of clipped along the left edge.
 - The tab you click to open those sidebars is no longer hidden behind the site navigation rail on tablet-sized screens — previously only a sliver of it peeked out.

## Implementation notes

The site navigation rail is `position: fixed; left: 0` at `z-index: 60`. The page-level off-canvas sidebars and their toggle tabs are also viewport-fixed at `left: 0`, at `z-30`–`z-50`. Between 768px and 1023px the rail is on screen but those page sidebars have not yet become in-flow columns (that happens at `lg`), so the rail painted over their first 4rem.

- `body` now carries `site-nav-open` / `site-nav-collapsed`, driven by the Alpine `showSidebar` state that already exists in the layout. The classes are only emitted for signed-in users, since the rail isn't rendered otherwise.
- A new `.site-nav-offset-left` rule, scoped to `@media (min-width: 768px) and (max-width: 1023px)`, offsets anything carrying the class past the rail: 4rem collapsed, 15rem expanded (`sm:w-60` at that breakpoint). Parallel `[data-sidebar-initial]` rules cover the frame before Alpine boots, so the always-visible toggle tab doesn't jump into place.
- Applied the class to the drawers and their mobile/tablet toggle tabs in `content/show`, `content/edit`, `timelines/edit`, and `documents/index`. The last two weren't in the original report but had the identical defect from the same pattern.

Deliberately left out: two pre-existing inconsistencies I noticed but didn't want to widen this PR with. The expanded rail is `sm:w-60` (15rem) between 768px and 1023px while `main` uses `md:ml-56` (14rem), so the expanded rail overlaps main content by 1rem in that range; and the pre-Alpine `[data-sidebar-initial="open"]` rules size it at 14rem, so there's a 1rem shift on boot. Happy to fix either separately if you want.

## Testing

No automated tests — this is CSS/markup only, and the repo has no view specs covering these layouts. Verified the stacking behaviour in headless Chromium against a reduced repro of the rail + drawer + the new rules: the drawer's left edge lands at 64px with the rail collapsed and 240px with it expanded at a 900px viewport, and stays at 0 at 500px and 1200px, where the offset must not apply.

I could not boot the app for a live check — `bundle install` hasn't been run in this container, so no gems are available.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FF1noksAeN94LLuGuZn71t)_