### PR TITLE
Show subscription plan status in navbar billing link

### DIFF
--- a/app/views/layouts/tailwind/navbar/_logged_in.html.erb
+++ b/app/views/layouts/tailwind/navbar/_logged_in.html.erb
@@ -290,8 +290,8 @@
           <%= link_to main_app.subscription_path, class: 'flex items-center px-4 py-2 cursor-pointer group hover:bg-notebook-blue dark:hover:bg-blue-600 hover:text-white' do %>
             <i class="material-icons text-notebook-blue dark:text-blue-400 shrink-0 w-8 h-8 mr-2 bg-white dark:bg-gray-700 rounded-full p-1">credit_card</i>
             <span class="flex-grow text-sm text-gray-900 dark:text-gray-100 group-hover:text-white">Billing</span>
-            <span class="bg-notebook-blue dark:bg-blue-500 text-white rounded px-1 text-xs group-hover:bg-orange-500">
-              PREMIUM
+            <span class="<%= current_user.on_premium_plan? ? 'bg-notebook-blue dark:bg-blue-500' : 'bg-gray-500 dark:bg-gray-600' %> text-white rounded px-1 text-xs group-hover:bg-orange-500">
+              <%= current_user.on_premium_plan? ? 'PREMIUM' : 'STARTER' %>
             </span>
           <% end %>
           <%= link_to thredded.private_topics_path, class: 'flex items-center px-4 py-2 cursor-pointer group hover:bg-notebook-blue dark:hover:bg-blue-600 hover:text-white' do %>


### PR DESCRIPTION
Fixes #

## User-facing changes

- The Billing link in the navbar now displays the user's current subscription plan (PREMIUM or STARTER) with appropriate styling based on their plan status

## Implementation notes

- Modified the navbar billing section to dynamically display the user's subscription plan using `current_user.on_premium_plan?`
- Premium users see a blue badge with "PREMIUM" text
- Non-premium users see a gray badge with "STARTER" text
- The badge styling is consistent with the existing design system, using Tailwind classes for light/dark mode support

## Testing

- Verified the conditional rendering logic displays correctly for both premium and non-premium users
- Existing navbar tests should cover this change

https://claude.ai/code/session_01JxqvazvvQw1MDnXVTDyhf2