### PR TITLE
Keep archived fields off content pages

### DIFF
--- a/app/models/serializers/content_serializer.rb
+++ b/app/models/serializers/content_serializer.rb
@@ -31,7 +31,11 @@ class ContentSerializer
     # self.attribute_values = Attribute.where(entity_type: content.page_type, entity_id: content.id)
     # self.fields           = AttributeField.where(id: self.attribute_values.pluck(:attribute_field_id).uniq)
     self.categories       = content.class.attribute_categories(content.user)
-    self.fields           = AttributeField.where(attribute_category_id: self.categories.map(&:id))
+    # Archived (hidden) fields stay out of every page view; their answers aren't
+    # touched, so restoring the field in the template editor brings them back.
+    # The name field is always kept, since pages are built around having one.
+    category_fields       = AttributeField.where(attribute_category_id: self.categories.map(&:id))
+    self.fields           = category_fields.where(hidden: [false, nil]).or(category_fields.where(field_type: 'name'))
     self.attribute_values = Attribute.where(attribute_field_id: self.fields.map(&:id), entity_type: content.page_type, entity_id: content.id)
     self.viewing_user     = viewing_user
 

--- a/test/models/content_serializer_archived_fields_test.rb
+++ b/test/models/content_serializer_archived_fields_test.rb
@@ -1,0 +1,112 @@
+require 'test_helper'
+
+class ContentSerializerArchivedFieldsTest < ActiveSupport::TestCase
+  def setup
+    @user = User.first
+
+    @category = AttributeCategory.create!(
+      user:        @user,
+      name:        'overview',
+      label:       'Overview',
+      entity_type: 'character'
+    )
+
+    @active_field = AttributeField.create!(
+      user:               @user,
+      attribute_category: @category,
+      label:              'Role',
+      name:               'role',
+      field_type:         'text_area'
+    )
+
+    @archived_field = AttributeField.create!(
+      user:               @user,
+      attribute_category: @category,
+      label:              'Old Notes',
+      name:               'old_notes',
+      field_type:         'text_area',
+      hidden:             true
+    )
+
+    @archived_category = AttributeCategory.create!(
+      user:        @user,
+      name:        'retired',
+      label:       'Retired',
+      entity_type: 'character',
+      hidden:      true
+    )
+
+    @field_in_archived_category = AttributeField.create!(
+      user:               @user,
+      attribute_category: @archived_category,
+      label:              'Retired Detail',
+      name:               'retired_detail',
+      field_type:         'text_area'
+    )
+
+    @character = Character.create!(user: @user, name: 'Archivist')
+
+    [@active_field, @archived_field, @field_in_archived_category].each do |field|
+      Attribute.create!(
+        user:            @user,
+        attribute_field: field,
+        entity:          @character,
+        value:           "value for #{field.label}"
+      )
+    end
+  end
+
+  def serialized_field_labels
+    ContentSerializer.new(@character, viewing_user: @user)
+      .data[:categories]
+      .flat_map { |category| category[:fields] }
+      .map { |field| field[:label] }
+  end
+
+  test "archived fields are left out of serialized page content" do
+    refute_includes serialized_field_labels, 'Old Notes'
+  end
+
+  test "active fields in the same category are still serialized" do
+    assert_includes serialized_field_labels, 'Role'
+  end
+
+  test "fields belonging to an archived category are left out too" do
+    refute_includes serialized_field_labels, 'Retired Detail'
+  end
+
+  test "archiving a field doesn't touch its stored answer" do
+    assert_equal 'value for Old Notes',
+      Attribute.find_by(attribute_field: @archived_field, entity: @character).value
+  end
+
+  test "restoring an archived field brings its answer back to the page" do
+    @archived_field.update!(hidden: false)
+
+    fields = ContentSerializer.new(@character, viewing_user: @user)
+      .data[:categories]
+      .flat_map { |category| category[:fields] }
+
+    restored = fields.detect { |field| field[:label] == 'Old Notes' }
+    assert restored.present?, 'expected the restored field to be serialized again'
+    assert_equal 'value for Old Notes', restored[:value]
+  end
+
+  test "an archived name field is still serialized so pages keep a name" do
+    name_field = AttributeField.create!(
+      user:               @user,
+      attribute_category: @category,
+      label:              'Name',
+      name:               'name',
+      field_type:         'name',
+      hidden:             true
+    )
+
+    serialized_ids = ContentSerializer.new(@character, viewing_user: @user)
+      .data[:categories]
+      .flat_map { |category| category[:fields] }
+      .map { |field| field[:internal_id] }
+
+    assert_includes serialized_ids, name_field.id
+  end
+end


### PR DESCRIPTION
Fixes # _(no issue — from a user report: "fields I archived in the previous site version are now showing on my pages")_

Changes proposed:

 - **Filter archived (hidden) fields out of `ContentSerializer`.** Archiving a field in the template editor sets `attribute_fields.hidden`, and the editor's own copy promises an active field "appears in your template and content pages." The serializer filtered archived *categories* (via `attribute_categories(user)`) but loaded **every** field in a surviving category regardless of its hidden flag, so archived fields that still had answers came back on the page after the redesign. Deleting the field was the only way to get rid of them.

 - **Fixed at the serializer rather than per-view.** The pre-redesign view honored this (`app/views/content/form/_panel.html.erb:25` still has `next if !!field[:hidden]`), but ~15 render sites now read `category[:fields]` and none re-check the flag — this bug exists precisely because new views forgot it. One filter at the shared choke point covers show, edit, quick reference, changelog, the smart sidebar, and the per-category completion percentages together.

 - **Answers are untouched; archiving stays reversible.** Only serialization changes, so restoring a field in the template editor brings its content straight back. The template editor (which queries `AttributeField` directly, `show_hidden: true`) and `ExportService.fetch_fields` (which intentionally exports everything, archived included) are deliberately unaffected.

 - **Name fields are kept even when hidden**, since pages are built around having one and the editor never offers to archive them (`_field_item.html.erb:85`). Purely defensive against legacy rows — without it, a hidden name field would blank the page title.

 - **Added `test/models/content_serializer_archived_fields_test.rb`** — 6 tests covering exclusion, restoration, answer preservation, archived categories, and the name-field carve-out.

### Testing

6/6 new tests pass. Verified the regression test actually bites: reverting the serializer change makes `test_archived_fields_are_left_out_of_serialized_page_content` fail.

Pre-existing failures I did **not** touch, all environmental or unrelated to this change:
- `test/models`: 1 failure + 4 errors — a `Document` status assertion, ActiveJob test helpers not mixed into `DocumentTest`, and Paperclip needing the ImageMagick `identify` binary.
- `test/controllers/content`: all error on an empty Webpacker manifest (packs aren't built in this container).

That last one means this was verified at the serializer level, not by rendering an actual show page in a browser.

### Follow-up (not in this PR)

While tracing consumers of the serialized `hidden:` key, I found the two views that read it are both orphaned — nothing renders `content/_form.html.erb` or `content/display/_category_panel.html.erb`, and no dynamic render path reaches them. Roughly 10 files appear stranded by the redesign, along with `CategoriesAndFieldsSerializer`. Worth a separate cleanup PR; note that `field_types/_link`, `_universe`, and `_tags` **are** live, so it isn't a directory-level delete.

@indentlabs/contributors

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7JcoLsyP2qYbBsDipRKVT)_