### PR TITLE
Handle deleted/archived pages in smart sidebar gracefully

### DIFF
--- a/app/models/serializers/content_serializer.rb
+++ b/app/models/serializers/content_serializer.rb
@@ -27,6 +27,10 @@ class ContentSerializer
   # }
 
   def initialize(content, viewing_user: nil)
+    # Callers sometimes look up the page they're serializing (and can come back empty-handed),
+    # so fail loudly here instead of raising a mystery NoMethodError on nil further down.
+    raise ArgumentError, "ContentSerializer was given a nil content page" if content.nil?
+
     # One query per table; lets not muck with joins yet
     # self.attribute_values = Attribute.where(entity_type: content.page_type, entity_id: content.id)
     # self.fields           = AttributeField.where(id: self.attribute_values.pluck(:attribute_field_id).uniq)

--- a/app/views/prompts/_smart_sidebar.html.erb
+++ b/app/views/prompts/_smart_sidebar.html.erb
@@ -6,7 +6,13 @@
 
 <%# todo extract "sidebar" and call it with @content, then also do the same in documents/components/smart_sidebar %>
 <%
+  # This can come back nil if the page has been deleted or archived since the cached
+  # ContentPage list this partial is rendered from was built, so we can't assume it's here.
   raw_model = content.page_type.constantize.find_by(id: content.id, user: current_user)
+%>
+
+<% if raw_model.present? %>
+<%
   serialized_entity = ContentSerializer.new(raw_model)
 %>
 
@@ -106,3 +112,4 @@
     <% end %>
   </li>
 </ul>
+<% end %>


### PR DESCRIPTION
Fixes #
<!-- A GitHub issue number, or a Sentry short ID like NOTEBOOK-AI-TX.
     Delete this line entirely if the PR isn't tied to one. -->

## User-facing changes

 - None (internal only)

## Implementation notes

The smart sidebar partial renders content from a cached list that may become stale if pages are deleted or archived. This change adds defensive checks to handle that scenario:

1. **In `_smart_sidebar.html.erb`**: Added a nil check around the sidebar rendering. If the page lookup returns nil (because the page was deleted/archived since the cache was built), the sidebar simply won't render rather than crashing.

2. **In `ContentSerializer`**: Added an explicit nil check in the initializer with a clear error message. This fails fast with a descriptive `ArgumentError` instead of allowing a mystery `NoMethodError` to occur later when the serializer tries to call methods on nil.

These changes work together: the view prevents nil from reaching the serializer in normal operation, while the serializer provides a safety net with better error messaging if nil somehow gets through.

## Testing

No new tests added. The changes are defensive guards that prevent errors in edge cases (deleted/archived pages). Existing tests should continue to pass as this doesn't change behavior for valid pages.

https://claude.ai/code/session_017knvD2VVk3RwE5gtMQNNME