### PR TITLE
Fix JSON response status codes in attribute controllers

### DIFF
--- a/app/controllers/attribute_categories_controller.rb
+++ b/app/controllers/attribute_categories_controller.rb
@@ -13,7 +13,7 @@ class AttributeCategoriesController < ContentController
   def successful_response(url, notice)
     respond_to do |format|
       format.html { redirect_to attribute_customization_path(content_type: @content.entity_type), notice: notice }
-      format.json { render json: @content || {}, status: :success, notice: notice }
+      format.json { render json: @content || {}, status: :ok }
     end
   end
 

--- a/app/controllers/attribute_fields_controller.rb
+++ b/app/controllers/attribute_fields_controller.rb
@@ -82,7 +82,7 @@ class AttributeFieldsController < ContentController
   def successful_response(url, notice)
     respond_to do |format|
       format.html { redirect_to attribute_customization_path(content_type: @content.attribute_category.entity_type), notice: notice }
-      format.json { render json: @content || {}, status: :success, notice: notice }
+      format.json { render json: @content || {}, status: :ok }
     end
   end
 


### PR DESCRIPTION
Fixes #

## User-facing changes

Saving an attribute field or category no longer returns a 500 error. The save itself already worked (the record was committed before the crash), but the JSON response blew up, so the UI reported a failure on a successful save.

Reported in Sentry as `NOTEBOOK-AI-16` — `ArgumentError: Unrecognized status code :success`, thrown from `AttributeFieldsController#update` on `PATCH /plan/attribute_fields/:id.json`.

## Implementation notes

`render json: ..., status: :success` is invalid: Rack's `SYMBOL_TO_STATUS_CODE` has no `:success` key (the symbol for 200 is `:ok`), so `_normalize_options` raised during render — after the `UPDATE` had already committed.

Changed to `status: :ok` in the `successful_response` JSON branch of:
- `app/controllers/attribute_fields_controller.rb`
- `app/controllers/attribute_categories_controller.rb`

Also dropped the trailing `notice: notice` from those two `render` calls. `render` silently ignores unknown options, so it never set a flash — it only looked like it did.

Base branch is `master`, since that's where the bug lives; `tailwind-redesign` already rewrote both `successful_response` methods to use `:ok`.

## Testing

No test added — `test/controllers/` currently has no coverage for either controller, and standing up request specs for them is broader than this fix. Verified by inspection against the Sentry stacktrace and breadcrumbs (record committed, then render raised).

## Screenshots

N/A

https://claude.ai/code/session_01MTQZaxH95i8uR7aHA25xjg