### PR TITLE
Fix dropdown menu alignment in content index

### DIFF
--- a/app/views/content/display/_tailwind_foldered_index.html.erb
+++ b/app/views/content/display/_tailwind_foldered_index.html.erb
@@ -287,7 +287,7 @@
                   <% end %>
                   <%= chevron_down %>
                 </button>
-                <div data-dropdown-target="menu" class="hidden origin-top-right absolute right-0 mt-2 w-64 rounded-lg shadow-lg bg-white dark:bg-gray-700 ring-1 ring-black ring-opacity-5 focus:outline-none z-10">
+                <div data-dropdown-target="menu" class="hidden origin-top-left absolute left-0 mt-2 w-64 rounded-lg shadow-lg bg-white dark:bg-gray-700 ring-1 ring-black ring-opacity-5 focus:outline-none z-10">
                   <div class="p-4">
                     <div class="space-y-3">
                       <% if @page_tags && @page_tags.any? %>


### PR DESCRIPTION
## User-facing changes

- Fixed dropdown menu positioning to align left instead of right in the content index view

## Implementation notes

Changed the dropdown menu in the tailwind foldered index from right-aligned (`origin-top-right absolute right-0`) to left-aligned (`origin-top-left absolute left-0`). This ensures the dropdown menu appears in the correct position relative to its trigger button.

## Testing

No testing needed. This is a straightforward CSS class change that corrects the visual positioning of an existing UI element.

https://claude.ai/code/session_01DNZd4YtdSCMEyKgADewGmJ